### PR TITLE
Fix for change in behavior of XMLMERGE in K5B.exe + small cleanups

### DIFF
--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -177,7 +177,7 @@ namespace Sample
       }
 
       // Import and commit logic projects with the changes we made:
-      wrapper.ImportLogicProjectsIntoZenon(true, ImportOptions.DoNotMerge);
+      wrapper.ImportLogicProjectsIntoZenon();
 
       // For zenon version 10 or higher, additional import options are available, e.g.:
       // wrapper.ImportLogicProjectsIntoZenon(true, ImportOptions.ReCreateVariables);

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using zenonApi.Logic;
+using zenonApi.Zenon;
 
 namespace Sample
 {
@@ -176,7 +177,11 @@ namespace Sample
       }
 
       // Import and commit logic projects with the changes we made:
-      wrapper.ImportLogicProjectsIntoZenon();
+      wrapper.ImportLogicProjectsIntoZenon(true, ImportOptions.DoNotMerge);
+
+      // For zenon version 10 or higher, additional import options are available, e.g.:
+      // wrapper.ImportLogicProjectsIntoZenon(true, ImportOptions.ReCreateVariables);
+
       wrapper.Dispose();
     }
   }

--- a/zenonApi.Core/Serialization/zenonSerializable.cs
+++ b/zenonApi.Core/Serialization/zenonSerializable.cs
@@ -1088,7 +1088,7 @@ namespace zenonApi.Serialization
           var entry = nodes[i];
           EnsureCompatibleEnumerableEntryType(entry.Type, genericType, targetArrayProperty);
 
-          if (ImportPrimitive(entry.Type, entry.Element.GetInnerXml(), out object value))
+          if (ImportPrimitive(entry.Type, entry.Element.Value, out object value))
           {
             targetArray.SetValue(value, i);
             entry.Element.Remove();
@@ -1145,7 +1145,7 @@ namespace zenonApi.Serialization
         foreach (var entry in nodes)
         {
           EnsureCompatibleEnumerableEntryType(entry.Type, genericType, targetListProperty);
-          if (ImportPrimitive(entry.Type, entry.Element.GetInnerXml(), out object value))
+          if (ImportPrimitive(entry.Type, entry.Element.Value, out object value))
           {
             targetList.Add(value);
             entry.Element.Remove();
@@ -1416,7 +1416,7 @@ namespace zenonApi.Serialization
 
         // Just try to deserialize the value directly
         var node = nodes[0].Element;
-        var nodeValue = node.GetInnerXml();
+        var nodeValue = node.Value;
         if (type.IsEnum)
         {
           foreach (var value in Enum.GetValues(type))
@@ -1470,7 +1470,7 @@ namespace zenonApi.Serialization
     private static void ImportNodeContent(IZenonSerializable target, XElement sourceXml, PropertyInfo property)
     {
       var zenonAttribute = property.GetCustomAttribute<zenonSerializableNodeContentAttribute>();
-      var nodeValue = sourceXml.GetInnerXml();
+      var nodeValue = sourceXml.Value;
       if (zenonAttribute == null || string.IsNullOrEmpty(nodeValue))
       {
         return;
@@ -1480,7 +1480,7 @@ namespace zenonApi.Serialization
       if (zenonAttribute.Converter != null)
       {
         IZenonSerializationConverter converterInstance = GetConverter(zenonAttribute.Converter);
-        property.SetValue(target, converterInstance.Convert(nodeValue));
+        property.SetValue(target, converterInstance.Convert(sourceXml.GetInnerXml()));
         sourceXml.Value = "";
       }
       else if (property.IsEnumOrNullableEnum(out bool isNullableEnum))

--- a/zenonApi.Logic.Integration/ImportOptions.cs
+++ b/zenonApi.Logic.Integration/ImportOptions.cs
@@ -28,6 +28,11 @@ namespace zenonApi.Zenon
     ///   Imports the logic project(s) and recreates variables if needed, but does not merge members.<br />
     ///   This option is equal to calling <c>K5B.exe</c> with argument <c>XMLMERGE-RV-NM</c>.
     /// </summary>
-    ReCreateVariablesDoNotMerge = 3
+    ReCreateVariablesDoNotMerge = 3,
+
+    /// <summary>
+    ///   Applies the online settings to the logic project.<br /> 
+    /// </summary>
+    ApplyOnlineSettings = 4
   }
 }

--- a/zenonApi.Logic.Integration/ImportOptions.cs
+++ b/zenonApi.Logic.Integration/ImportOptions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace zenonApi.Zenon
+{
+  /// <summary>
+  ///   Specifies import options to use for importing a <see cref="Logic.LogicProject"/> into zenon.
+  /// </summary>
+  [Flags]
+  public enum ImportOptions
+  {
+    /// <summary>
+    ///   The default setting for importing logic projects into zenon.<br />
+    ///   This will not recreate variables and will merge import files with existing projects.<br />
+    ///   This option is equal to calling the <c>K5B.exe</c> with argument <c>XMLMERGE</c>.
+    /// </summary>
+    Default = 0,
+    /// <summary>
+    ///   Imports or merges the logic project(s) and additionally recreates variables if needed.<br />
+    ///   This option is equal to calling <c>K5B.exe</c> with argument <c>XMLMERGE-RV</c>.
+    /// </summary>
+    ReCreateVariables = 1,
+    /// <summary>
+    ///   Imports the logic project(s) but does not merge members.<br />
+    ///   This option is equal to calling <c>K5B.exe</c> with argument <c>XMLMERGE-NM</c>.
+    /// </summary>
+    DoNotMerge = 2,
+    /// <summary>
+    ///   Imports the logic project(s) and recreates variables if needed, but does not merge members.<br />
+    ///   This option is equal to calling <c>K5B.exe</c> with argument <c>XMLMERGE-RV-NM</c>.
+    /// </summary>
+    ReCreateVariablesDoNotMerge = 3
+  }
+}

--- a/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
+++ b/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
@@ -213,19 +213,30 @@ namespace zenonApi.Zenon.K5Prp
     /// <summary>
     /// Imports the stated <see cref="LogicProject"/> into zenon Logic.
     /// </summary>
-    /// <param name="zenonLogicProject"></param>
-    /// <returns></returns>
-    internal bool ImportZenonLogicProject(LogicProject zenonLogicProject)
+    /// <param name="zenonLogicProject">The project to import into zenon.</param>
+    /// <param name="options">Specifies options on how to import the <paramref name="zenonLogicProject"/> into zenon.</param>
+    internal bool ImportZenonLogicProject(LogicProject zenonLogicProject, ImportOptions options)
     {
       string xmlFilePathToImport = SerializeZenonLogicProjectToXmlFile(zenonLogicProject);
+      string option = "XMLMERGE";
+      if (options.HasFlag(ImportOptions.ReCreateVariables))
+      {
+        option += "-RV";
+      }
 
-      // import via K5B.exe
-      ProcessStartInfo startInfo
-        = new ProcessStartInfo(K5BexeFilePath, $"XMLMERGE {this.ZenonLogicProjectDirectory} {xmlFilePathToImport}")
-        {
-          CreateNoWindow = false,
-          WindowStyle = ProcessWindowStyle.Hidden
-        };
+      if (options.HasFlag(ImportOptions.DoNotMerge))
+      {
+        option += "-NM";
+      }
+
+      string arguments = $"{option} {this.ZenonLogicProjectDirectory} {xmlFilePathToImport}";
+
+      // Import via K5B.exe
+      ProcessStartInfo startInfo = new ProcessStartInfo(K5BexeFilePath, arguments)
+      {
+        CreateNoWindow = false,
+        WindowStyle = ProcessWindowStyle.Hidden
+      };
 
       using (Process stratonXmlImportProcess = new Process { StartInfo = startInfo })
       {

--- a/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
+++ b/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
@@ -257,17 +257,16 @@ namespace zenonApi.Zenon.K5Prp
       bool allSucceeded
         = TryApplySettings(zenonLogicProject.Settings.CompilerSettings.CompilerOptions.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>());
 
-      allSucceeded
-        = TryApplySettings(zenonLogicProject.Settings.CompilerSettings.SimulationCodeOptions.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
-        && allSucceeded;
-
-      allSucceeded
-        = TryApplySettings(zenonLogicProject.Settings.CompilerSettings.TargetCodeOptions.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
-        && allSucceeded;
-
-      allSucceeded
-        = TryApplySettings(zenonLogicProject.Settings.OnlineChangeSettings.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
-        && allSucceeded;
+      // According to CD-FR the following three setting sections shall never be set manually.
+      //allSucceeded
+      //  = TryApplySettings(zenonLogicProject.Settings.CompilerSettings.SimulationCodeOptions.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
+      //  && allSucceeded;
+      //allSucceeded
+      //  = TryApplySettings(zenonLogicProject.Settings.CompilerSettings.TargetCodeOptions.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
+      //  && allSucceeded;
+      //allSucceeded
+      //  = TryApplySettings(zenonLogicProject.Settings.OnlineChangeSettings.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>())
+      //  && allSucceeded;
 
       uint cycleTime = zenonLogicProject.Settings.TriggerTime.CycleTime;
       if (cycleTime == 0)

--- a/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
+++ b/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
@@ -348,16 +348,6 @@ namespace zenonApi.Zenon.K5Prp
       return allSucceeded;
     }
 
-    private bool TryApplySrvSettings(K5SrvWrapper srv, LogicOptionTuple option)
-    {
-      if(option.Name.Equals("enable"))
-      {
-        return SetSrvOption(srv, K5SrvConstants.K5DbProperty.EnableHot, option.Value);
-      }
-
-      return true;
-    }
-
     private bool TryApplySettings(IEnumerable<LogicOptionTuple> options)
     {
       bool allSucceeded = true;

--- a/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
+++ b/zenonApi.Logic.Integration/K5Prp/K5ToolSet.cs
@@ -27,6 +27,11 @@ namespace zenonApi.Zenon.K5Prp
     /// </summary>
     private const string ZenonLogicCompileLogFileName = "__build.log";
 
+    /// <summary>
+    /// Windows message to be posted to the callback window when a database event is notified.
+    /// </summary>
+    private const uint messageCallback = 0x400;
+
     static K5ToolSet()
     {
       K5PCall = (K5PRPCall)LoadFunction<K5PRPCall>("K5PRPCall");
@@ -304,14 +309,14 @@ namespace zenonApi.Zenon.K5Prp
 
       allSucceeded = SetOption("CycleTime", cycleTime.ToString()) && allSucceeded;
 
-      if (!options.Equals(ImportOptions.ApplyOnlineSettings))
+      if (!options.HasFlag(ImportOptions.ApplyOnlineSettings))
       {
         return allSucceeded;
       }
 
       IntPtr windowHandle = Process.GetCurrentProcess().MainWindowHandle;
       string clientName = System.Reflection.Assembly.GetExecutingAssembly().GetName().Name;
-      K5SrvWrapper srv = K5SrvWrapper.TryConnect(windowHandle, 0x0400, zenonLogicProject.Path, clientName, K5SrvConstants.K5DbSelfNotif);
+      K5SrvWrapper srv = K5SrvWrapper.TryConnect(windowHandle, messageCallback, zenonLogicProject.Path, clientName, K5SrvConstants.K5DbSelfNotif);
 
       allSucceeded &= TryApplyOnlineChangeSettings(srv, zenonLogicProject.Settings.OnlineChangeSettings.OptionTuples ?? Enumerable.Empty<LogicOptionTuple>());
       srv.Dispose();

--- a/zenonApi.Logic.Integration/K5Srv/DbFile.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbFile.cs
@@ -1,0 +1,8 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public class DbFile
+  {
+    public uint Id;
+    public string Value = string.Empty;
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbGroup.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbGroup.cs
@@ -1,0 +1,14 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public class DbGroup
+    {
+      public uint Id;
+      public string Name = string.Empty;
+
+      public uint GroupStyle;
+      public uint IoType;
+      public uint Slot;
+      public uint SubSlot;
+      public uint Var;
+    }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbProgram.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbProgram.cs
@@ -1,0 +1,17 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public partial class K5SrvWrapper
+  {
+    public class DbProgram
+    {
+      public uint ProgramId;
+      public string Name = string.Empty;
+
+      public uint Language = (uint)K5SrvConstants.K5DbLanguage.Any;
+      public uint Section = (uint)K5SrvConstants.K5DbSection.Any;
+      public uint ParentHandle;
+
+      public string Path = string.Empty;
+    }
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbProp.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbProp.cs
@@ -1,0 +1,8 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public class DbProp
+  {
+    public uint Id;
+    public string Value = string.Empty;
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbSrv.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbSrv.cs
@@ -1,0 +1,696 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace zenonApi.Zenon.K5Srv
+{
+  internal static class DbSrv
+  {
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVersion")]
+    public static extern int GetVersion(); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetKindOfObject")]
+    public static extern uint GetKindOfObject(uint dwId);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_IsObjectLocked")]
+    public static extern uint IsObjectLocked(uint dwId); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CheckSymbol")]
+    public static extern uint CheckSymbol(string szName); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetGhostName")]
+    private static extern IntPtr _GetGhostName(uint dwId); 
+
+    public static string GetGhostName(uint dwId)
+    {
+      IntPtr propertyPointer = _GetGhostName(dwId);
+      return Marshal.PtrToStringAnsi(propertyPointer);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_Connect")]
+    public static extern uint Connect(IntPtr handleWindowCallback, uint msgCallback,
+      uint dwFlags, uint dwData,
+      string szClientName); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetCallback")]
+    public static extern uint
+      SetCallback(uint hClient, IntPtr handleWindowCallback, uint msgCallback); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_Disconnect")]
+    public static extern void Disconnect(uint client);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetClientName")]
+    private static extern IntPtr _GetClientName(uint client); 
+
+    public static string GetClientName(uint client)
+    {
+      IntPtr ptrProp = _GetClientName(client);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetMessage")]
+    private static extern IntPtr _GetMessage(uint dwRc); 
+
+    public static string GetMessage(uint dwRc)
+    {
+      IntPtr ptrProp = _GetMessage(dwRc);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetEventDesc")]
+    private static extern IntPtr _GetEventDesc(uint dwEvent, ref uint pdwFlags); 
+
+    public static string GetEventDesc(uint dwEvent, ref uint pdwFlags)
+    {
+      IntPtr ptrProp = _GetEventDesc(dwEvent, ref pdwFlags);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DispatchEvent")]
+    public static extern uint
+      DispatchEvent(uint hClient, uint hProject, uint dwEvent, uint dwArg); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_EnableEvents")]
+    public static extern uint
+      EnableEvents(uint hClient, uint hProject, uint dwEnable); 
+
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_OpenProject")]
+    public static extern uint OpenProject(uint hClient, string szProjectPath); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CloseProject")]
+    public static extern void CloseProject(uint hClient, uint hProject); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProjectPath")]
+    public static extern uint GetProjectPath(uint hClient, uint hProject, StringBuilder sPath);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SaveProject")]
+    public static extern uint SaveProject(uint hClient, uint hProject); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProjectDateStamp")]
+    public static extern uint GetProjectDateStamp(uint hClient, uint hProject); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetProjectModified")]
+    public static extern uint SetProjectModified(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbProgram")]
+    public static extern uint
+      GetNbProgram(uint hClient, uint hProject, uint dwSection);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetPrograms")]
+    public static extern uint
+      GetPrograms(uint hClient, uint hProject, uint dwSection,
+        uint[] arrPrg); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbChildren")]
+    public static extern uint
+      GetNbChildren(uint hClient, uint hProject, uint hParent); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetChildren")]
+    public static extern uint
+      GetChildren(uint hClient, uint hProject, uint hParent,
+        uint[] arrChild);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindProgram")]
+    public static extern uint FindProgram(uint hClient, uint hProject, string szProgName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProgramDesc")]
+    public static extern IntPtr GetProgramDesc(uint hClient, uint hProject, uint hProgram,
+      ref uint dwLanguage, ref uint dwSection, ref uint hParent);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CanCreateProgram")]
+    public static extern uint CanCreateProgram(uint hClient, uint hProject,
+      uint dwLanguage, uint dwSection, uint hParent,
+      string szProgName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CreateProgram")]
+    public static extern uint CreateProgram(uint hClient, uint hProject,
+      uint dwLanguage, uint dwSection, uint hParent,
+      string szProgName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CopyProgram")]
+    public static extern uint CopyProgram(uint hClient, uint hProject,
+      uint hProgram, uint dwSection, uint hParent,
+      string szProgName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RenameProgram")]
+    public static extern uint RenameProgram(uint hClient, uint hProject,
+      uint hProgram, string szNewName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_MoveProgram")]
+    public static extern uint MoveProgram(uint hClient, uint hProject,
+      uint hProgram, uint dwMove, uint hParent);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DeleteProgram")]
+    public static extern uint DeleteProgram(uint hClient, uint hProject, uint hProgram);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LockProgram")]
+    public static extern uint
+      LockProgram(uint hClient, uint hProject, uint hProgram);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SaveProgramChanges")]
+    public static extern uint
+      SaveProgramChanges(uint hClient, uint hProject, uint hProgram);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_UnlockProgram")]
+    public static extern uint
+      UnlockProgram(uint hClient, uint hProject, uint hProgram);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProgramOwner")]
+    private static extern IntPtr
+      _GetProgramOwner(uint hClient, uint hProject, uint hProgram);
+
+    public static string GetProgramOwner(uint hClient, uint hProject, uint hProgram)
+    {
+      IntPtr ptrProp = _GetProgramOwner(hClient, hProject, hProgram);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProgramPath")]
+    public static extern uint GetProgramPath(uint hClient, uint hProject, uint hProgram,
+      StringBuilder szPath);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProgramSchedule")]
+    public static extern uint GetProgramSchedule(uint hClient, uint hProject, uint hProgram,
+      ref uint pdwPeriod, ref uint pdwOffset);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetProgramSchedule")]
+    public static extern uint SetProgramSchedule(uint hClient, uint hProject, uint hProgram,
+      uint dwPeriod, uint dwOffset);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProgramOnCallFlag")]
+    public static extern uint
+      GetProgramOnCallFlag(uint hClient, uint hProject, uint hProgram);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetProgramOnCallFlag")]
+    public static extern uint
+      SetProgramOnCallFlag(uint hClient, uint hProject, uint hProgram, uint dwOnCall);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_ExportProgram")]
+    public static extern uint
+      ExportProgram(uint hClient, uint hProject, uint hProgram, string szExportFileName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_ImportProgram")]
+    public static extern uint ImportProgram(uint hClient, uint hProject, string szImportFileName,
+      string szWishedName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetImportProgramName")]
+    public static extern uint GetImportProgramName(uint hClient, string szImportFileName,
+      StringBuilder szNameBuffer, uint dwBufSize);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbType")]
+    public static extern uint GetNbType(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetTypes")]
+    public static extern uint
+      GetTypes(uint hClient, uint hProject, uint[] arrTypes);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindType")]
+    public static extern uint FindType(uint hClient, uint hProject, string szType);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetTypeDesc")]
+    public static extern IntPtr
+      GetTypeDesc(uint hClient, uint hProject, uint hType, ref uint dwFlags);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetTypeUDFB")]
+    public static extern uint
+      GetTypeUDFB(uint hClient, uint hProject, uint hType);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbTypeParam")]
+    public static extern uint
+      GetNbTypeParam(uint hClient, uint hProject, uint hType);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetTypeParams")]
+    public static extern uint
+      GetTypeParams(uint hClient, uint hProject, uint hType,
+        uint[] arrParams);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetUDFBNbIO")]
+    public static extern uint GetUDFBNbIO(uint hClient, uint hProject, uint hType, ref uint pdwNbIn,
+      ref uint pdwNbOut); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RenameType")]
+    public static extern uint
+      RenameType(uint hClient, uint hProject, uint hType, string szNewName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DeleteType")]
+    public static extern uint
+      DeleteType(uint hClient, uint hProject, uint hType); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CreateEnumType")]
+    public static extern uint
+      CreateEnumType(uint hClient, uint hProject, string szName,
+        string szValues); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetEnumTypeValues")]
+    public static extern IntPtr
+      GetEnumTypeValues(uint hClient, uint hProject, uint hType); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetEnumTypeValues")]
+    public static extern uint
+      SetEnumTypeValues(uint hClient, uint hProject, uint hType,
+        string szValues); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CreateBitFieldType")]
+    public static extern uint CreateBitFieldType(uint hClient, uint hProject, uint hBaseType, string szName,
+      string szBits); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetBitFieldType")]
+    public static extern IntPtr
+      GetBitFieldType(uint hClient, uint hProject, uint hType,
+        ref uint phBaseType); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetBitFieldType")]
+    public static extern uint SetBitFieldType(uint hClient, uint hProject, uint hType, uint hBaseType,
+      string szBits); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbGroup")]
+    public static extern uint GetNbGroup(uint hClient, uint hProject); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetGroups")]
+    public static extern uint
+      GetGroups(uint hClient, uint hProject, uint[] arrGroups); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetSortedGroups")]
+    public static extern uint
+      GetSortedGroups(uint hClient, uint hProject, uint[] arrGroups,
+        uint dwSort); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindGroup")]
+    public static extern uint FindGroup(uint hClient, uint hProject, string szGroupName); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetGroupDesc")]
+    public static extern IntPtr GetGroupDesc(uint hClient, uint hProject, uint hGroup,
+      ref uint dwGroupStyle, ref uint hIoType,
+      ref uint dwSlot, ref uint dwSubSlot,
+      ref uint nbVar); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LockGroup")]
+    public static extern uint LockGroup(uint hClient, uint hProject, uint hGroup);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_UnlockGroup")]
+    public static extern uint
+      UnlockGroup(uint hClient, uint hProject, uint hGroup);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetGroupOwner")]
+    private static extern IntPtr
+      _GetGroupOwner(uint hClient, uint hProject, uint hGroup);
+
+    public static string GetGroupOwner(uint hClient, uint hProject, uint hGroup)
+    {
+      IntPtr ptrProp = _GetGroupOwner(hClient, hProject, hGroup);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LockGroupEx")]
+    public static extern uint
+      LockGroupEx(uint hClient, uint hProject, uint hGroup);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_UnlockGroupEx")]
+    public static extern uint
+      UnlockGroupEx(uint hClient, uint hProject, uint hGroup);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbVar")]
+    public static extern uint
+      GetNbVar(uint hClient, uint hProject, uint hGroup); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVars")]
+    public static extern uint GetVars(uint hClient, uint hProject, uint hGroup,
+      uint[] arrVars);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetSortedVars")]
+    public static extern uint GetSortedVars(uint hClient, uint hProject, uint hGroup,
+      uint dwMethod, uint[] arrVars);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindVarInGroup")]
+    public static extern uint FindVarInGroup(uint hClient, uint hProject, uint hGroup,
+      string szVarName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CreateVar")]
+    public static extern uint CreateVar(uint hClient, uint hProject, uint hGroup,
+      uint dwPosId, uint hType, uint dwDim, uint dwStringLength,
+      uint dwFlags, string szVarName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DeleteVar")]
+    public static extern uint
+      DeleteVar(uint hClient, uint hProject, uint hGroup, uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RenameVar")]
+    public static extern uint RenameVar(uint hClient, uint hProject, uint hGroup, uint hVar,
+      string szNewName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CanRenameVar")]
+    public static extern uint CanRenameVar(uint hClient, uint hProject, uint hGroup, uint hVar,
+      string szNewName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarPrevName")]
+    private static extern IntPtr
+      _GetVarPrevName(uint hClient, uint hProject, uint hVar);
+
+    public static string GetVarPrevName(uint hClient, uint hProject, uint hVar)
+    {
+      IntPtr ptrProp = _GetVarPrevName(hClient, hProject, hVar);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_MoveVar")]
+    public static extern uint MoveVar(uint hClient, uint hProject, uint hGroup, uint hVar, uint dwPosId);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarGroup")]
+    public static extern uint
+      GetVarGroup(uint hClient, uint hProject, uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarDesc")]
+    public static extern IntPtr GetVarDesc(uint hClient, uint hProject, uint hGroup, uint hVar,
+      ref uint hType, ref uint dwDim, ref uint dwStringLength,
+      ref uint dwFlags);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetVarDesc")]
+    public static extern uint SetVarDesc(uint hClient, uint hProject, uint hGroup, uint hVar,
+      uint hType, uint dwDim, uint dwStringLength, uint dwFlags);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CanSetVarDesc")]
+    public static extern uint CanSetVarDesc(uint hClient, uint hProject, uint hGroup, uint hVar,
+      uint hType, uint dwDim, uint dwStringLength, uint dwFlags);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetVarInitValue")]
+    public static extern uint SetVarInitValue(uint hClient, uint hProject, uint hGroup, uint hVar,
+      string szValue);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CheckVarInitValue")]
+    public static extern uint CheckVarInitValue(uint hClient, uint hProject, uint hGroup, uint hVar,
+      string szValue);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarInitValue")]
+    private static extern IntPtr _GetVarInitValue(uint hClient, uint hProject, uint hGroup, uint hVar,
+      ref uint pdwValid);
+
+    public static string GetVarInitValue(uint hClient, uint hProject, uint hGroup, uint hVar,
+      ref uint pdwValid)
+    {
+      IntPtr ptrProp = _GetVarInitValue(hClient, hProject, hGroup, hVar, ref pdwValid);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LockVar")]
+    public static extern uint
+      LockVar(uint hClient, uint hProject, uint hGroup, uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_UnlockVar")]
+    public static extern uint
+      UnlockVar(uint hClient, uint hProject, uint hGroup, uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarOwner")]
+    private static extern IntPtr
+      _GetVarOwner(uint hClient, uint hProject, uint hVar);
+
+    public static string GetVarOwner(uint hClient, uint hProject, uint hVar)
+    {
+      IntPtr ptrProp = _GetVarOwner(hClient, hProject, hVar);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindVar")]
+    public static extern uint FindVar(uint hClient, uint hProject, string szSymbol, uint hStartPos,
+      uint hLocalGroup, uint dwFlags);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindProgramVar")]
+    public static extern uint FindProgramVar(uint hClient, uint hProject, uint hProgram, string szVarName,
+      ref uint phGroup, ref uint pbLocal);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetVarDimensions")]
+    public static extern uint GetVarDimensions(uint hClient, uint hProject, uint hGroup, uint hVar,
+      uint dwBufSize, uint[] arrFims);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetVarDimensions")]
+    public static extern uint SetVarDimensions(uint hClient, uint hProject, uint hGroup, uint hVar,
+      uint dwBufSize, uint[] arrFims);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SerUserGroups")]
+    public static extern uint SerUserGroups(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbProp")]
+    public static extern uint
+      GetNbProp(uint hClient, uint hProject, uint hObject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProps")]
+    public static extern uint
+      GetProps(uint hClient, uint hProject, uint hObject, uint[] arrProps);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetProperty")]
+    public static extern uint SetProperty(uint hClient, uint hProject, uint hObject, uint hProp,
+      string szValue); // assign a value to a property
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetProperty")]
+    private static extern IntPtr
+      _GetProperty(uint hClient, uint hProject, uint hObject, uint hProp);
+
+    public static string GetProperty(uint hClient, uint hProject, uint hObject, K5SrvConstants.K5DbProperty hProp)
+    {
+      IntPtr ptrProp = _GetProperty(hClient, hProject, hObject, (uint)hProp);
+      return Marshal.PtrToStringAnsi(ptrProp);
+    }
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RemoveProperties")]
+    public static extern uint
+      RemoveProperties(uint hClient, uint hProject, uint hObject); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetComment")]
+    public static extern uint SetComment(uint hClient, uint hProject, uint hObject,
+      uint dwCommType, string szValue);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetComment")]
+    public static extern uint GetComment(uint hClient, uint hProject, uint hObject,
+      uint dwCommType,
+      StringBuilder szBuffer, uint dwBufSize);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetCommentLength")]
+    public static extern uint GetCommentLength(uint hClient, uint hProject, uint hObject,
+      uint dwCommType);
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SelectVar")]
+    public static extern bool SelectVar(uint hClient, uint hProject, string szText, ref SelectedVariable selectedVariable,
+      ref uint phVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetSerBuffer")]
+    public static extern IntPtr GetSerBuffer(uint hClient);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RealeaseSerBuffer")]
+    public static extern void ReleaseSerBuffer(uint hClient);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetSerBuffer")]
+    public static extern void SetSerBuffer(uint hClient, string szText);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SerializeVar")]
+    public static extern uint
+      SerializeVar(uint hClient, uint hProject, uint hGroup, uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_PasteSerializedVar")]
+    public static extern uint
+      PasteSerializedVar(uint hClient, uint hProject, uint hGroup, uint dwPosId);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetGlobalFilePath")]
+    public static extern uint GetGlobalFilePath(uint hClient, uint hProject, string szSuffix,
+      StringBuilder szPath); 
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetEqvPath")]
+    public static extern uint GetEqvPath(uint hClient, uint hProject, uint bCommon, uint hProgram,
+      StringBuilder szPath);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_PutHotSettings")]
+    public static extern uint PutHotSettings(uint hClient, uint hProject, uint dwEnabled, uint dwStamp,
+      string szSettings);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_IsHotEnabled")]
+    public static extern uint IsHotEnabled(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SetHotSizing")]
+    public static extern void SetHotSizing(uint hClient, uint hProject, string szSettings);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_EnableHot")]
+    public static extern void EnableHot(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DisableHot")]
+    public static extern void DisableHot(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CleanHotTracks")]
+    public static extern uint CleanHotTracks(uint hClient, uint hProject);
+
+    // enumerate child sub items of a complex item ////////////////////////
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetExpSubItems")]
+    public static extern uint GetExpSubItems(uint hClient, uint hProject, uint hParentProgram, string szText,
+      ref uint dwMinIndex, ref uint dwMaxIndex, ref uint hVar);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetNbFile")]
+    public static extern uint
+      GetNbFile(uint hClient, uint hProject, string szExt);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetFiles")]
+    public static extern uint
+      GetFiles(uint hClient, uint hProject, string szExt, uint[] arrFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_FindFile")]
+    public static extern uint FindFile(uint hClient, uint hProject, string szName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_GetFileDesc")]
+    public static extern IntPtr GetFileDesc(uint hClient, uint hProject, uint hFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CanCreateFile")]
+    public static extern uint CanCreateFile(uint hClient, uint hProject, string szName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CreateFile")]
+    public static extern uint CreateFile(uint hClient, uint hProject, string szName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_RenameFile")]
+    public static extern uint
+      RenameFile(uint hClient, uint hProject, uint hFile, string szNewName);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_DeleteFile")]
+    public static extern uint DeleteFile(uint hClient, uint hProject, uint hFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LockFile")]
+    public static extern uint LockFile(uint hClient, uint hProject, uint hFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_UnlockFile")]
+    public static extern uint UnlockFile(uint hClient, uint hProject, uint hFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_SaveFileChanges")]
+    public static extern uint SaveFileChanges(uint hClient, uint hProject, uint hFile);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_LookForNewFiles")]
+    public static extern uint LookForNewFiles(uint hClient, uint hProject);
+
+    [DllImport("K5DBSrv.dll", CallingConvention = CallingConvention.Cdecl,
+      EntryPoint = "K5DB_CopyFile")]
+    public static extern uint
+      CopyFile(uint hClient, uint hProject, uint hFile, string szDstName);
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbType.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbType.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace zenonApi.Zenon.K5Srv
+{
+  public class DbType
+  {
+    public uint TypeId;
+    public string Name = string.Empty;
+
+    public uint Flags;
+
+    public uint UdfbHandle;
+    public uint In;
+    public uint Out;
+
+    public List<DbVar> ParameterList = new List<DbVar>();
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/DbVar.cs
+++ b/zenonApi.Logic.Integration/K5Srv/DbVar.cs
@@ -1,0 +1,15 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public class DbVar
+    {
+      public uint Id;
+      public string Name = string.Empty;
+
+      public uint Type;
+      public uint Dim;
+      public uint StringLength;
+      public uint Flags;
+
+      public string InitialValue = string.Empty;
+    }
+}

--- a/zenonApi.Logic.Integration/K5Srv/K5SrvConstants.cs
+++ b/zenonApi.Logic.Integration/K5Srv/K5SrvConstants.cs
@@ -1,0 +1,464 @@
+﻿namespace zenonApi.Zenon.K5Srv
+{
+  public class K5SrvConstants
+  {
+    public const string K5DbGroupNameGlobal = "(Global)";
+    public const string K5DbGroupNameRentain = "(Retain)";
+
+    // index of the first event text
+    public const int K5DbEventTextIndex = 100;
+
+    // first available id for declared objects
+    public const int K5DbIdUser = 256; 
+
+    // Client connection flags
+    public const uint K5DbSelfNotif = 0x00000001; // flag: self-notifications wished
+
+    #region Method return constants
+
+    /// <summary>
+    ///   Enum for the different K5Srv error codes
+    /// </summary>
+    public enum K5DbErr
+    {
+      Ok = 0, // OK
+
+      Internal = 1, // internal error - not documented
+      SameRename = 2, // rename with same name
+
+      CreateProject = 3, // cant create project
+      UnknownClient = 4, // invalid client handle
+      UnknownProject = 5, // invalid project handle
+      ProjectShared = 6, // project is shared - cant be deleted
+      DeleteProject = 7, // cant delete project
+      RenameProject = 8, // cant rename project
+      CopyProject = 9, // cant rename project
+
+      UnknownProgram = 10, // unknown program
+      DuplicateProgram = 11, // program name already used
+      BadProgramName = 12, // invalid program name
+      DeleteParentProgram = 13, // parent program cant be deleted
+      ProgramLocked = 14, // program is locked
+      BadProgramMove = 15, // invalid program move in hierarchy
+      TooManyPrograms = 16, // too many programs
+      BadProgramSection = 17, // invalid section
+      BadProgramLanguage = 18, // invalid language
+
+      UnknownGroup = 19, // unknown group
+      CantDeleteGroup = 20, // cant delete group (not an IO)
+      GroupLocked = 21, // group is locked
+
+      CantDeleteVariable = 22, // cant delete variable in an IO group
+      UnknownVariable = 23, // unknown variable in group
+      VariableLocked = 24, // variable is locked
+      CantRenameVariable = 25, // cant rename variable in an IO group
+      DuplicateVariableName = 26, // variable name already used
+      BadVariableName = 27, // variable name already used
+      UnknownType = 28, // unknow type
+      BadIoType = 29, // invalid change of IO type
+      IoVariableDimension = 30, // IO cant have no dim
+      TypeDimension = 31, // type cant have a dim
+      BadDimension = 32, // invalid dim
+      NoStringLength = 33, // type cant have a string length
+      BadStringLength = 34, // invalid string length
+      CantChangeAttribute = 35, // invalid change of attribute
+      CantChangeRo = 36, // RO attribute cant be changed
+      CantAliasMemoryVariable = 37, // aliases are only for IOs
+      CantInitFb = 38, // no init value for FB instances
+      CantInitArray = 39, // no init value for arrays
+      BadInitValue = 40, // invalid init value
+      NoFbIoInit = 41, // FB In/Out cannot have an initial value
+      FbIoVariableArray = 42, // FB in/out cannot have dimension
+
+      UnknownObject = 43, // unknown object (in project)
+
+      BadCommentLanguage = 44, // invalid text language identifier
+      NoVariableMultiLineComment = 45, // no multiline comm for variables
+      NoRetainInstance = 46, // no instances in RETAIN group
+
+      ExportCantCreate = 47, // cant create export file
+      ImportCantRead = 48, // cant open import file
+      ImportBadFile = 49, // invalid import file
+      ImportCreateFile = 50, // cant create import program
+      ExportHideUdfb = 51, // cant hide exported source if not UDFB
+      ExportHideNoCode = 52, // cant hide exported source if UDFB not compiled
+
+      HotEnabled = 53, // invalid operation when On Line change is enabled
+      Xv = 54, // invalid use of "external" attributes
+
+      DlgAskCreateVar = 55, // DlgAskCreateVar
+      DlgType = 56, // DlgType
+      DlgYes = 57, // DlgYes
+      DlgNo = 58, // DlgNo
+      DlgCancel = 59, // DlgCancel
+      DlgCreateVarKo = 60, // DlgCreateVarKO
+
+      CantDeleteFolder = 61, // del non empty folder
+      CantRenameFolder = 62, // folder name used
+      CantMoveChildToFolder = 63, // cant move child program to folder
+      CantMoveTopFolder = 64, // cant move root folder
+      CantMoveFolderSame = 65, // cant move to the same folder
+      CantMoveFolderRecurs = 66, // cant move to chil folder
+
+      FileLocked = 67, // file is locked
+      BadFileExtention = 68, // invalid file extension
+      DuplicateFileName = 69, // file name already used
+      BadFileName = 70, // invalid file name
+
+      Crypted = 71, // program is protected
+
+      DlgAskVar = 72, // DlgAskVar
+      DlgAskCreate = 73, // DlgAskCreate
+      DlgAskRename = 74, // DlgAskRename
+      DlgRange = 75, // DlgRange
+
+      BadEnum = 76, // invalid enumerated value(s)
+      DuplicateTypeName = 77, // type name already used
+
+      DlgVariables = 78, // variables
+      DlgKeywords = 79, // keywords and functions
+      DlgNoGroup = 80, // (no user group)
+      DlgAll = 81, // (all)
+
+      DlgLocalOnly = 82, // local variables only
+      DlgNoInstance = 83, // no FB instance
+
+      Global = 84, // "GLOBAL"
+      Retain = 85, // "RETAIN"
+      PromptDisableProgram = 86, // prompt to disable instead of delete when hot enabled
+    }
+    #endregion
+
+    #region Object types
+    /// <summary>
+    ///   Enum for the different K5Srv files
+    /// </summary>
+    public enum K5DbObj
+    {
+      Client = 1, // client
+      Project = 2, // open project
+      Program = 3, // program
+      Group = 4, // group
+      Type = 5, // type (may refer to a UDFB)
+      Var = 6, // variable
+      Unknown = 7, // external object (not stored)
+      Folder = 8, // program folders
+      File = 9, // program folders
+    }
+    #endregion
+    /// <summary>
+    ///   Enum for the different K5Srv events
+    /// </summary>
+    public enum K5DbEvent : uint
+    {
+      Build = 0x80000001, // application built
+      BuildOptions = 0x80000002, // build options changed
+      Download = 0x80000003, // application downloaded
+      LoadChange = 0x80000004, // application changes downloaded
+      HotChange = 0x80000005, // on line change
+      EqvCom = 0x80000006, // common defines changed
+      EqvGlobal = 0x80000007, // global defines changed
+      HistoryOn = 0x80000008, // history activated
+      HistoryOff = 0x80000009, // history deactivated
+      WatchFiles = 0x8000000a, // watch file(s) have changed - obsolete
+      ConfigChanged = 0x8000000b, // active configuration has changed
+      LibsChanged = 0x8000000c, // libraries have been updated
+      BeforeLoop = 0x8000000d, // internal use
+      AfterLoop = 0x8000000e, // internal use
+
+      HotChanged = 0x000a0001, // hot settings have changed
+
+      FileNew = 0x000e0001, // new file has been created
+      FileRenamed = 0x000e0002, // file name has been changed
+      FileDeleted = 0x000e0003, // file has been deleted
+      FileLocked = 0x000e0004, // file has been locked
+      FileUnlocked = 0x000e0005, // file has been unlocked
+      FileChanged = 0x000e0006, // file contents has been changed
+      FilesReloaded = 0x000e0007, // files have been re-scanned
+
+      ProjectRenamed = 0x00010001, // project has been renamed / moved on disk
+      ProjectReloaded = 0x00010002, // project has been reloaded
+
+      ProgramNew = 0x00020001, // new program has been created
+      ProgramDuplicatd = 0x00020002, // new program has been created by copy
+      ProgramRenamed = 0x00020003, // program has been renamed
+      ProgramDeleted = 0x00020004, // program has been deleted
+      ProgramMoved = 0x00020005, // program has been moved
+      ProgramCopied = 0x00020006, // program has been copied
+      ProgramLocked = 0x00020007, // program has been locked for editing
+      ProgramChanged = 0x00020008, // edited program has been changed and saved
+      ProgramUnlocked = 0x00020009, // program has been unlocked after editing
+      ProgramVariablesChanged = 0x0002000a, // local variables have changed
+
+      CommentLanguageChanged = 0x00090001, // selected language has changed
+      CommentChanged = 0x00090003, // a comment has changed
+
+      TypeNew = 0x00050001, // new type has been created
+      TypeRenamed = 0x00050003, // type has been renamed
+      TypeDeleted = 0x00050004, // type has been deleted
+      TypeChanged = 0x00050007, // type has been changed
+
+      GroupNew = 0x00040001, // new group has been created
+      GroupRenamed = 0x00040002, // group has been renamed
+      GroupDeleted = 0x00040003, // group has been deleted
+      GroupLocked = 0x00040004, // group has been locked
+      GroupChanged = 0x00040005, // group has been changed (itself - not vars inside)
+      GroupUnlocked = 0x00040006, // group has been unlocked
+      GroupMoved = 0x00040007, // group has been moved
+
+      GroupOwned = 0x00040008, // group + its vars has been locked
+      GroupReleased = 0x00040009, // group + its vars has been locked
+
+      K5PropertyChanged = 0x00080001, // K5 reserved property has changed
+      ExternalPropertyChanged = 0x00080002, // external property has changed
+
+      VariableNew = 0x00070001, // new variable has been created
+      VariableRenamed = 0x00070002, // variable name or IO alias has been changed
+      VariableDeleted = 0x00070003, // variable has been deleted
+      VariableLocked = 0x00070004, // variable has been locked
+      VariableChanged = 0x00070005, // variable has been changed
+      VariableUnlocked = 0x00070006, // variable has been unlocked
+      VariableMoved = 0x00070007, // variable has been moved within its parent group
+      VariableBeginMove = 0x00070008, // variable will be moved (arg: hVar before)
+      VariableEndMove = 0x00070009, // move is finished (arg: hVar after or NULL if fail)
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv sections
+    /// </summary>
+    public enum K5DbSection
+    {
+      Begin = 0x00000001, // BEGIN (non sfc)
+      Sfc = 0x00000002, // SFC: main only
+      End = 0x00000004, // END (non sfc)
+      Child = 0x00000008, // SFC children (all)
+      Udfb = 0x00000010, // UDFBs
+      Main = 0x00000007, // all main programs - not UDFBs
+      Prog = 0x0000000f, // all programs
+      Any = 0x000000ff, // all programs and UDFBs
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv programming languages
+    /// </summary>
+    public enum K5DbLanguage : uint
+    {
+      // programming languages
+      Sfc = 0x00000001, // SFC
+      St = 0x00000002, // ST
+      Fbd = 0x00000004, // FBD
+      Ld = 0x00000008, // LD
+      Il = 0x00000010, // IL
+      FreeFormSfc = 0x00000020, // free form SFC
+      Any = 0x0000001f, // any language
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv move actions
+    /// </summary>
+    public enum K5DbMoveProgram
+    {
+      Up = 1, // up in the same section
+      Down = 2, // down in the same section
+      Begin = 3, // to BEGIN section
+      End = 4, // to END section
+      SfcMain = 5, // to top of SFC section
+      ChildOf = 6, // under the specified SFC parent program
+      Before = 7, // before the specified program
+      After = 8, // after the specified program
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv types
+    /// </summary>
+    public enum K5DbType
+    {
+      Invalid = 0x00001000, // invalid data type
+      Basic = 0x00000001, // simple data type (predefined)
+      String = 0x00000002, // string length is required
+      Io = 0x00000004, // type can be used for an IO
+      CStruct = 0x00000008, // structure defined in libray
+      StandardFb = 0x00000010, // that's a standard or "C" function block
+      Cfb = 0x00000020, // that's a standard or "C" function block
+      Udfb = 0x00000040, // thats a UDFB
+      Fb = 0x000000f0, // that's a function block or a UDFB
+      Enum = 0x00000100, // enumeratade data type (user defined)
+      BitField = 0x00000200, // bit field integer data type (user defined)
+
+      Single = (Basic | Enum | BitField),
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv groups
+    /// </summary>
+    public enum K5DbGroup : uint
+    {
+      Global = 1, // global variables
+      Retain = 2, // global RETAIN variables
+      Input = 3, // input IO board
+      Output = 4, // output IO board
+      ComplexInput = 5, // input IO board within a complex device
+      ComplexOutput = 6, // output IO board within a complex device
+      Local = 7, // variables local to a program		
+      Udfb = 8, // private data and parameters of a UDFB
+
+      SortDefault = 0, // natural order
+      SortIoLast = 1, // IOs are the last ones
+      SortNatural = 2, // natural order - sorted by class
+      SortLocal = 0x80000000, // 1 local first - OR combined with local group handle
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv max values
+    /// </summary>
+    public enum K5DbMax
+    {
+      Dim = 65534,
+      String = 255,
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv variable properties
+    /// </summary>
+    public enum K5DbVar
+    {
+      ReadOnly = 0x00000001, // read only attribute (always TRUE for inputs)
+      Input = 0x00000002, // physical input
+      Output = 0x00000004, // physical output
+      FbInput = 0x00000008, // input parameter of a FB or UDFB
+      FbOutput = 0x00000010, // output parameter of a FB or UDFB
+      Extern = 0x00000020, // shared external variable
+      InOut = 0x00000040, // FB input is INOUT
+      Added = 0x00000100, // added for on line change
+      Deleted = 0x00000200, // deleted for on line change
+      LocalRetain = 0x00000400, // local RETAIN flag
+
+      FindExact = 0x00000001, // find exact name
+      FindPvid = 0x00000002, // find by PVID
+
+      SortByName = 1, // sort by variable name
+      SortByType = 2, // sort by data type
+      SortByAttribute = 3, // sort by attribute
+      SortByProperties = 4, // sort by properties (profile & embedded)
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv move parameters
+    /// </summary>
+    public enum KbDbMoveParam
+    {
+      Up = 1, // move command: FB parameter UP
+      Down = 2, // move command: FB parameter DOWN
+      ToEnd = 3, // move command: move to end of group (vars only)
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv properties
+    /// </summary>
+    public enum K5DbProperty
+    {
+      User = 4096, // 1rst available prop ID for external apps
+
+      // predefined properties - project
+      CycleTiming = 1, // cycle triggering (project's property)
+      TargetSizing = 2, // target memory sizing for On Line Change (syntax in RTL)
+      EnableHot = 3, // enable on line change (when defined)
+      LastChange = 4, // date stamp of last change bad for on line change
+      ProjectHistory = 5, // project history settings
+      Versioning = 6, // project version info
+      IoChannelBase = 7, // base index for IO channels
+      TargetCtSizing = 8, // min size of CT segment (for On Line Change)
+      Config = 9, // active configuration name
+      IsLibrary = 10, // non null if project is library
+      LastLibraryUpdate = 11, // time stamp of last updates of libraries
+      PaScript = 12, // no null if PA scripting project
+      FbUndef = 13, // list of undef fieldbuses (\t separated)
+      CommunicationSetting = 14, // communication settings
+      BindPort = 15, // port use for the binding
+      CommunicationDriver = 16, // communication driver
+      K5MonitoringDestination = 17, // Monitoring builder default destination folder
+      NonIecSyb = 18, // allow non IEC variable names
+      OnlineConstants = 19, // Constants and init values can be changed On Line
+      PrjVarUid = 20, // next unique ID for On Line Change
+      DdkHide = 21, // list of hidden configs (DLL prefixes, separated by ',')
+      LibList = 128, // properties after are library folders
+      Folder = 256, // properties after this number are reserved to K5DBSRV
+
+      // predefined properties - programs and types
+      ProgramSchedule = 1, // program scheduling: '%period=offset'
+      ProgramOnCall = 2, // program flag: 'on call' exec mode
+      ProgramTask = 3, // task name (NULL = default cycle)
+      UdfbStructure = 4, // UDFB is a data structure
+      ProgramCheck = 5, // program validity: "#FALSE#" if not valid
+      ProgramPath = 6, // path in folder tree
+      ProgramVisible = 7, // reserved for WB
+      ProgramFamily = 8, // group family name
+      Library = 9, // library path
+      Crypt = 10, // program has been crypred
+      Hidden = 11, // program is hidden in workspace
+      InstianciableSfc = 12, // instianciable SFC langguage
+      ProgramOemEdit = 13, // OEM dll for editing
+      ProgramColor = 14, // optional RGB color
+      UdfbSama = 15, // UDFB is usable in SAMA
+      UdfbSamaShape1 = 16, // customized shape for SAMA UDFB
+      UdfbSamaShape2 = 17, // customized shape for SAMA UDFB
+      UdfbSamaShape3 = 18, // customized shape for SAMA UDFB
+      UdfbSamaShape4 = 19, // customized shape for SAMA UDFB
+      UdfbSamaShape5 = 20, // customized shape for SAMA UDFB
+      UdfbSamaShape6 = 21, // customized shape for SAMA UDFB
+      UdfbSamaShape7 = 22, // customized shape for SAMA UDFB
+      UdfbSamaShape8 = 23, // customized shape for SAMA UDFB
+      ProgramOwned = 40, // this program is managed by another part of straton
+
+      // predefined properties - IO groups
+      IoGroupKey = 1, // driver key for an IO board
+      IoGroupOem = 2, // first OEM defined property
+      IoGroupName = 256, // driver name for an IO board / name of a complex
+      IoParentName = 257, // parent driver name for an complex IO board
+      IoVirtual = 258, // parent driver name for an complex IO board
+
+      // predefined properties - variables
+      VariableEmbedded = 1, // variable embedded properties
+      VariableProfile = 2, // variable profile
+
+      VariableDimension = 3, // array multi dimensions: readable: D1,D2[,D3]
+
+      // undefined if less than 2 dimensions
+      VariableHide = 4, // hide variable: [ "<EDIT>" ] [ "<SEL>" ]
+      VariableFdbFlow = 5, // FBD flow (hidden) - NULL or "FBDFLOW"
+      VariablePvid = 6, // zenon PVID
+      VariableShared = 7, // shared for multitasking
+      VariableUid = 8, // unique ID for On Line Change
+      VariableUserGroup1 = 256, // user defined group name
+      VariableUserGroup2 = 257, // user defined group name
+      VariableUserGroup3 = 258, // user defined group name
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv comments
+    /// </summary>
+    public enum K5DbComment
+    {
+      Short = 1, // short tag for graphic languages
+      Long = 2, // long description text
+      Multiline = 3, // multiline description text
+    }
+
+    /// <summary>
+    ///   Enum for the different K5Srv variable selections
+    /// </summary>
+    public enum K5DbVariableSelection
+    {
+      NoTextSelected = 0x00000001, // no text selected if edit box
+      CreateVariable = 0x00000002, // create var if not existing
+      Debug = 0x00000004, // debug mode (False=edit)
+      FocusEdit = 0x00000008, // focus edit box at open
+      DefaultPosition = 0x00000010, // dont apply window position
+      Complete = 0x00000020, // completion mode (filter possible vars)
+      ShowAlways = 0x00000040, // always display box (even if 1 choice)
+      CreateOnly = 0x00000080, // no selection - check for exist and create
+      FilterType = 0x00000100, // use preferred type for filtering list
+      FromList = 0x00000200, // list of items passed by the caller
+    }
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/K5SrvWrapper.cs
+++ b/zenonApi.Logic.Integration/K5Srv/K5SrvWrapper.cs
@@ -1,0 +1,1509 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+
+namespace zenonApi.Zenon.K5Srv
+{
+  public partial class K5SrvWrapper : IDisposable
+  {
+    private bool isDisposed = false;
+    private uint _clientHandle;
+    private uint _projectHandle;
+    private K5SrvWrapper() {}
+
+    /// <summary>
+    ///   Open a connection to the logic database
+    /// </summary>
+    /// <returns> K5SvrWrapper object if successful</returns>
+    /// <param name="handleWindowCallback">Window callback of current application.</param>
+    /// <param name="messageCallback">Message callback handle.</param>
+    /// <param name="projectPath">Path to the zenon logic project.</param>
+    /// <param name="clientName">Name of the accessing application.</param>
+    /// <param name="flags">Flags to specify connection.</param>
+    public static K5SrvWrapper TryConnect(IntPtr handleWindowCallback, uint messageCallback, string projectPath, string clientName, uint flags)
+    {
+      K5SrvWrapper srv = new K5SrvWrapper();
+
+      if (srv.Open(handleWindowCallback, messageCallback, projectPath, clientName, flags))
+      {
+        return srv;
+      }
+      
+      return null;
+    }
+
+    /// <summary>
+    ///   Open a connection to the logic database
+    /// </summary>
+    /// <returns> Bool, true if successful</returns>
+    /// <param name="handleWindowCallback">Window callback of current application.</param>
+    /// <param name="messageCallback">Message callback handle.</param>
+    /// <param name="projectPath">Path to the zenon logic project.</param>
+    /// <param name="clientName">Name of the accessing application.</param>
+    /// <param name="flags">Flags to specify connection.</param>
+    public bool Open(IntPtr handleWindowCallback, uint messageCallback, string projectPath, string clientName, uint flags)
+    {
+      Close();
+
+      _clientHandle = DbSrv.Connect(handleWindowCallback, messageCallback, flags, 0, clientName);
+      if (_clientHandle != 0)
+      {
+        _projectHandle = DbSrv.OpenProject(_clientHandle, projectPath);
+        if (_projectHandle == 0)
+        {
+          DbSrv.Disconnect(_clientHandle);
+          _clientHandle = 0;
+        }
+      }
+
+      return IsReady;
+    }
+
+    public bool OpenQuiet(string projectPath)
+    {
+      IntPtr ptr = new IntPtr(0);
+      return Open(ptr, 0, projectPath, "", 0);
+    }
+
+    /// <summary>
+    ///   Closes the connection
+    /// </summary>
+    public void Close()
+    {
+      if (_projectHandle != 0)
+      {
+        DbSrv.CloseProject(_clientHandle, _projectHandle);
+        _projectHandle = 0;
+      }
+
+      if (_clientHandle != 0)
+      {
+        DbSrv.Disconnect(_clientHandle);
+        _clientHandle = 0;
+      }
+    }
+
+    /// <summary>
+    ///   Handle of the logic project
+    /// </summary>
+    public uint ProjectHandle => _projectHandle;
+
+    /// <summary>
+    ///   Handle of the client
+    /// </summary>
+    public uint ClientHandle => _clientHandle;
+
+    /// <summary>
+    ///   Indicates if project can be accessed
+    /// </summary>
+    public bool IsReady => _projectHandle != 0;
+
+    /// <summary>
+    ///   Name of the client
+    /// </summary>
+    public string ClientName => DbSrv.GetClientName(_clientHandle);
+
+    /// <summary>
+    ///   Indicates if project is a library
+    /// </summary>
+    public bool IsLibrary
+    {
+      get
+      {
+        if (_projectHandle == 0)
+          return false;
+
+        CheckIfDisposed();
+
+        string property = DbSrv.GetProperty(_clientHandle, _projectHandle, _projectHandle, K5SrvConstants.K5DbProperty.IsLibrary);
+
+        return property != null;
+      }
+    }
+
+    /// <summary>
+    ///   Indicates if project is a PA script
+    /// </summary>
+    public bool IsPaScript
+    {
+      get
+      {
+        if (_projectHandle == 0)
+          return false;
+
+        CheckIfDisposed();
+
+        string property = DbSrv.GetProperty(_clientHandle, _projectHandle, _projectHandle,
+          K5SrvConstants.K5DbProperty.PaScript);
+
+        return property != null;
+      }
+    }
+
+    /// <summary>
+    ///   Returns the object type of the object
+    /// </summary>
+    /// <returns> Type of object</returns>
+    /// <param name="id">ObjectID.</param>
+    public K5SrvConstants.K5DbObj GetKindOfObject(uint id)
+    {
+      CheckIfDisposed();
+      return (K5SrvConstants.K5DbObj)DbSrv.GetKindOfObject(id);
+    }
+
+    /// <summary>
+    ///   Checks if the object is locked
+    /// </summary>
+    public bool IsObjectLocked(uint id)
+    {
+      CheckIfDisposed();
+      return DbSrv.IsObjectLocked(id) != 0;
+    }
+
+
+    public uint CheckSymbol(string name)
+    {
+      CheckIfDisposed();
+      return DbSrv.CheckSymbol(name);
+    }
+
+    public string GetGhostName(uint id)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetGhostName(id);
+    }
+
+    public string GetMessage(uint messageId)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetMessage(messageId);
+    }
+
+    public string GetEventDescription(uint eventId, ref uint flags)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetEventDesc(eventId, ref flags);
+    }
+
+    public bool DispatchEvent(uint eventId, uint arguments)
+    {
+      CheckIfDisposed();
+      return DbSrv.DispatchEvent(_clientHandle, _projectHandle, eventId, arguments) == (uint) K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Enables events in the logic project
+    /// </summary>
+    public uint EnableEvents(uint enable)
+    {
+      CheckIfDisposed();
+      return DbSrv.EnableEvents(_clientHandle, _projectHandle, enable);
+    }
+
+    /// <summary>
+    ///   Return the path of the logic project
+    /// </summary>
+    public string GetProjectPath()
+    {
+      CheckIfDisposed();
+
+      StringBuilder pathBuild = new StringBuilder(256);
+      DbSrv.GetProjectPath(_clientHandle, _projectHandle, pathBuild);
+
+      string path = pathBuild.ToString();
+      return path;
+    }
+
+    /// <summary>
+    ///   Saves changes in the logic project
+    /// </summary>
+    public bool SaveProject()
+    {
+      CheckIfDisposed();
+      return DbSrv.SaveProject(_clientHandle, _projectHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public uint ProjectTimeStamp()
+    {
+      CheckIfDisposed();
+      return DbSrv.GetProjectDateStamp(_clientHandle, _projectHandle);
+    }
+
+    /// <summary>
+    ///   Sets project state to modified
+    /// </summary>
+    public bool SetProjectModified()
+    {
+      CheckIfDisposed();
+      return DbSrv.SetProjectModified(_clientHandle, _projectHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    } 
+
+    /// <summary>
+    ///   Requests the program list from the database which are available after this method executed in parameter
+    /// </summary>
+    /// <returns>List which contains the found programs</returns>
+    /// <param name="section">The section of which programs shall be retrieved.</param>
+    public List<DbProgram> GetPrograms(K5SrvConstants.K5DbSection section)
+    {
+      CheckIfDisposed();
+
+      List<DbProgram> programs = new List<DbProgram>();
+
+      if (_projectHandle == 0)
+        return programs;
+
+      uint nbProg = DbSrv.GetNbProgram(_clientHandle, _projectHandle, (uint)section);
+      if (nbProg == 0)
+        return programs;
+
+      //create program array
+      uint[] arrPrg = new uint[nbProg];
+      DbSrv.GetPrograms(_clientHandle, _projectHandle, (uint)section, arrPrg);
+
+      for (uint uPrg = 0; uPrg < nbProg; uPrg++)
+      {
+        DbProgram prog = new DbProgram();
+        programs.Add(prog);
+        GetProgramDesc(arrPrg[uPrg], ref prog);
+      }
+
+      return programs;
+    }
+
+    /// <summary>
+    ///   Get description of the specified program
+    /// </summary>
+    /// <returns>Bool, true if description found</returns>
+    /// <param name="programHandle">The program handle.</param>
+    /// <param name="dbProgram">The program (object DbProgram).</param>
+    public bool GetProgramDesc(uint programHandle, ref DbProgram dbProgram)
+    {
+      CheckIfDisposed();
+
+      dbProgram.ProgramId = programHandle;
+
+      IntPtr ptrName = DbSrv.GetProgramDesc(_clientHandle, _projectHandle, programHandle, ref dbProgram.Language,
+        ref dbProgram.Section, ref dbProgram.ParentHandle);
+      dbProgram.Name = Marshal.PtrToStringAnsi(ptrName);
+
+      StringBuilder strPath = new StringBuilder(256);
+      DbSrv.GetProgramPath(_clientHandle, _projectHandle, programHandle, strPath);
+      dbProgram.Path = strPath.ToString();
+
+      return dbProgram.Name != null;
+    }
+
+    /// <summary>
+    ///   Get children of a parent SFC
+    /// </summary>
+    /// <returns>List which contains the found children</returns>
+    /// <param name="programHandle">The parent sfc program.</param>
+    public List<DbProgram> GetChildren(uint programHandle)
+    {
+      CheckIfDisposed();
+
+      List<DbProgram> programList = new List<DbProgram>();
+
+      if (_projectHandle == 0)
+        return programList;
+
+      uint nbChild = DbSrv.GetNbChildren(_clientHandle, _projectHandle, programHandle);
+      if (nbChild == 0)
+        return programList;
+
+      uint[] arrChild = new uint[nbChild];
+      DbSrv.GetChildren(_clientHandle, _projectHandle, programHandle, arrChild);
+      for (uint uChild = 0; uChild < nbChild; uChild++)
+      {
+        DbProgram progChild = new DbProgram();
+        programList.Add(progChild);
+        GetProgramDesc(arrChild[uChild], ref progChild);
+      }
+
+      return programList;
+    }
+
+    /// <summary>
+    ///   Gets the related program id of a group or type
+    /// </summary>
+    /// <returns>ID of the program</returns>
+    /// <param name="id">ID of group or type.</param>
+    public uint GetRelatedProgramId(uint id) // group or type
+    {
+      CheckIfDisposed();
+
+      uint programId = 0;
+      switch (GetKindOfObject(id))
+      {
+        case K5SrvConstants.K5DbObj.Program:
+          programId = id;
+          break;
+
+        case K5SrvConstants.K5DbObj.Group:
+          DbGroup group = new DbGroup();
+          if (GetGroupDesc(id, ref group))
+            programId = FindProgram(group.Name);
+          break;
+
+        case K5SrvConstants.K5DbObj.Type:
+          DbType type = new DbType();
+          if (GetTypeDesc(id, ref type))
+            programId = FindProgram(type.Name);
+          break;
+      }
+
+      return programId;
+    }
+
+    /// <summary>
+    ///   Checks if a object is a structure
+    /// </summary>
+    /// <returns> Bool, true if successful</returns>
+    /// <param name="id">ID of object.</param>
+    public bool IsStructure(uint id)
+    {
+      CheckIfDisposed();
+
+      id = GetRelatedProgramId(id);
+      string prop = GetProperty(id, K5SrvConstants.K5DbProperty.UdfbStructure);
+
+      return prop != null;
+    }
+
+    /// <summary>
+    ///   Returns program id
+    /// </summary>
+    /// <param name="programName">Name of the program.</param>
+    public uint FindProgram(string programName)
+    {
+      CheckIfDisposed();
+
+      return DbSrv.FindProgram(_clientHandle, _projectHandle, programName);
+    }
+
+    /// <summary>
+    ///   Checks if a program can be created
+    /// </summary>
+    /// <param name="language">Language of the program.</param>
+    /// <param name="section">Section of the program.</param>
+    /// <param name="handleParent">Handle of the parent object.</param>
+    /// <param name="programName">Program name.</param>
+    public bool CanCreateProgram(K5SrvConstants.K5DbLanguage language, K5SrvConstants.K5DbSection section, uint handleParent, string programName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CanCreateProgram(_clientHandle, _projectHandle, (uint)language, (uint)section, handleParent, programName) ==
+             (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Creates a program in zenon logic
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="language">Language of the program.</param>
+    /// <param name="section">Section of the program.</param>
+    /// <param name="handleParent">Handle of the parent object.</param>
+    /// <param name="programName">Program name.</param>
+    public uint CreateProgram(uint languageId, uint sectionId, uint handleParent, string programName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CreateProgram(_clientHandle, _projectHandle, languageId, sectionId, handleParent, programName);
+    }
+
+    /// <summary>
+    ///   Copies a program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the existing program.</param>
+    /// <param name="section">Section of the program.</param>
+    /// <param name="handleParent">Handle of the parent object.</param>
+    /// <param name="programName">Program name.</param>
+    public uint CopyProgram(uint handleProgram, uint section, uint handleParent, string programName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CopyProgram(_clientHandle, _projectHandle, handleProgram, section, handleParent, programName);
+    }
+
+    /// <summary>
+    ///   Renames a program
+    /// </summary>
+    /// <param name="handleProgram">Handle of the existing program.</param>
+    /// <param name="newName">New program name.</param>
+    public bool RenameProgram(uint handleProgram, string newName)
+    {
+      CheckIfDisposed();
+      return DbSrv.RenameProgram(_clientHandle, _projectHandle, handleProgram, newName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Moves the program
+    /// </summary>
+    /// <param name="handleProgram">Handle of the program.</param>
+    /// <param name="move">Move location.</param>
+    /// <param name="handleParent">Handle of the parent object.</param>
+    public bool MoveProgram(uint handleProgram, K5SrvConstants.K5DbMoveProgram move, uint handleParent)
+    {
+      CheckIfDisposed();
+      return DbSrv.MoveProgram(_clientHandle, _projectHandle, handleProgram, (uint)move, handleParent) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Deletes a program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    public bool DeleteProgram(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.DeleteProgram(_clientHandle, _projectHandle, handleProgram) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Locks the program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    public bool LockProgram(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.LockProgram(_clientHandle, _projectHandle, handleProgram) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Saves changes of the program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    public bool SaveProgramChanges(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.SaveProgramChanges(_clientHandle, _projectHandle, handleProgram) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Unlocks the program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    public bool UnlockProgram(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.UnlockProgram(_clientHandle, _projectHandle, handleProgram) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Return the owner of the program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    public string GetProgramOwner(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetProgramOwner(_clientHandle, _projectHandle, handleProgram);
+    }
+     
+    public bool GetProgramSchedule(uint handleProgram, ref uint period, ref uint offset)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetProgramSchedule(_clientHandle, _projectHandle, handleProgram, ref period, ref offset) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool SetProgramSchedule(uint handleProgram, uint period, uint offset)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetProgramSchedule(_clientHandle, _projectHandle, handleProgram, period, offset) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool GetProgramOnCallFlag(uint handleProgram)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetProgramOnCallFlag(_clientHandle, _projectHandle, handleProgram) != 0;
+    }
+
+    public bool SetProgramOnCallFlag(uint handleProgram, uint onCallFlag)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetProgramOnCallFlag(_clientHandle, _projectHandle, handleProgram, onCallFlag) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Exports a program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="handleProgram">Handle of the program.</param>
+    /// <param name="exportFileName">Path of the exported file.</param>
+    public bool ExportProgram(uint handleProgram, string exportFileName)
+    {
+      CheckIfDisposed();
+      return DbSrv.ExportProgram(_clientHandle, _projectHandle, handleProgram, exportFileName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Imports a program
+    /// </summary>
+    /// <returns> ID of the program</returns>
+    /// <param name="importFileName">Path of the program to import.</param>
+    /// <param name="wishedName">Name of the program</param>
+    public bool ImportProgram(string importFileName, string wishedName)
+    {
+      CheckIfDisposed();
+      return DbSrv.ImportProgram(_clientHandle, _projectHandle, importFileName, wishedName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+
+    public bool GetImportProgramName(string importFileName, StringBuilder nameBuffer, uint bufferSize)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetImportProgramName(_clientHandle, importFileName, nameBuffer, bufferSize) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///  Get the type list in database
+    /// </summary>
+    /// <returns>List which contains the found types</returns>
+    public List<DbType> GetTypes()
+    {
+      CheckIfDisposed();
+
+      List<DbType> typeList = new List<DbType>();
+
+      if (_projectHandle == 0)
+        return typeList;
+
+      uint nbType = DbSrv.GetNbType(_clientHandle, _projectHandle);
+      if (nbType == 0)
+        return typeList;
+
+      //create type array
+      uint[] arrType = new uint[nbType];
+      DbSrv.GetTypes(_clientHandle, _projectHandle, arrType);
+
+      for (uint uType = 0; uType < nbType; uType++)
+      {
+        DbType type = new DbType();
+        typeList.Add(type);
+        GetTypeDesc(arrType[uType], ref type);
+      }
+
+      return typeList;
+    }
+
+    /// <summary>
+    ///   Get description of the specified type
+    /// </summary>
+    /// <returns> Bool, true if description found</returns>
+    /// <param name="typeHandle">The type handle.</param>
+    /// <param name="type">The type (object DbType).</param>
+    public bool GetTypeDesc(uint typeHandle, ref DbType type)
+    {
+      CheckIfDisposed();
+
+      type.TypeId = typeHandle;
+
+      IntPtr ptrName = DbSrv.GetTypeDesc(_clientHandle, _projectHandle, typeHandle, ref type.Flags);
+      type.Name = Marshal.PtrToStringAnsi(ptrName);
+
+      type.UdfbHandle = DbSrv.GetTypeUDFB(_clientHandle, _projectHandle, typeHandle);
+      DbSrv.GetUDFBNbIO(_clientHandle, _projectHandle, typeHandle, ref type.In, ref type.Out);
+
+      uint nbParam = DbSrv.GetNbTypeParam(_clientHandle, _projectHandle, typeHandle);
+      if (nbParam != 0)
+      {
+        uint[] arrParam = new uint[nbParam];
+        DbSrv.GetTypeParams(_clientHandle, _projectHandle, typeHandle, arrParam);
+
+        for (uint uParam = 0; uParam < nbParam; uParam++)
+        {
+          DbVar var = new DbVar();
+          type.ParameterList.Add(var);
+          GetVarDesc(arrParam[uParam], ref var);
+        }
+      }
+
+      return type.Name != null;
+    }
+
+    /// <summary>
+    ///   Searches the defined type
+    /// </summary>
+    /// <returns> ID of the found type</returns>
+    /// <param name="type">Name of the type.</param>
+    public uint FindType(string type)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindType(_clientHandle, _projectHandle, type);
+    }
+
+    /// <summary>
+    ///   Renames a type
+    /// </summary>
+    /// <param name="typeHandle">Handle of the type.</param>
+    /// <param name="newName">New name of the type.</param>
+    public bool RenameType(uint typeHandle, string newName)
+    {
+      CheckIfDisposed();
+      return DbSrv.RenameType(_clientHandle, _projectHandle, typeHandle, newName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Deletes the type
+    /// </summary>
+    /// <param name="typeHandle">Handle of the type to rename.</param>
+    public bool DeleteType(uint typeHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.DeleteType(_clientHandle, _projectHandle, typeHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Creates an enum type
+    /// </summary>
+    /// <returns> ID of the created enum</returns>
+    /// <param name="name">Name of the enum.</param>
+    /// <param name="values">Values of the enum.</param>
+    public uint CreateEnumType(string name, string values)
+    {
+      CheckIfDisposed();
+      return DbSrv.CreateEnumType(_clientHandle, _projectHandle, name, values);
+    }
+
+    /// <summary>
+    ///   Returns the values of an enum type
+    /// </summary>
+    /// <param name="typeHandle">Handle of the enum type.</param>
+    public string GetEnumTypeValues(uint typeHandle)
+    {
+      CheckIfDisposed();
+      IntPtr ptr = DbSrv.GetEnumTypeValues(_clientHandle, _projectHandle, typeHandle);
+      return Marshal.PtrToStringAnsi(ptr);
+    }
+
+    /// <summary>
+    ///   Sets values of an enum type
+    /// </summary>
+    /// <param name="typeHandle">Handle of the enum type.</param>
+    /// <param name="values">values of the enum.</param>
+    public bool SetEnumTypeValues(uint typeHandle, string values)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetEnumTypeValues(_clientHandle, _projectHandle, typeHandle, values) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public uint CreateBitFieldType(uint baseTypeHandle, string name, string bits)
+    {
+      CheckIfDisposed();
+      return DbSrv.CreateBitFieldType(_clientHandle, _projectHandle, baseTypeHandle, name, bits);
+    }
+
+    public string GetBitFieldType(uint typeHandle, ref uint baseTypeHandle)
+    {
+      CheckIfDisposed();
+      IntPtr ptr = DbSrv.GetBitFieldType(_clientHandle, _projectHandle, typeHandle, ref baseTypeHandle);
+      return Marshal.PtrToStringAnsi(ptr);
+    }
+
+    public bool SetBitFieldType(uint typeHandle, uint baseTypeHandle, string bits)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetBitFieldType(_clientHandle, _projectHandle, typeHandle, baseTypeHandle, bits) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Get the group list in database
+    /// </summary>
+    /// <returns> List which contains the found groups</returns>
+    /// <param name="sortMethod">The sorting method to retrieve groups.</param>
+    public List<DbGroup> GetGroups(K5SrvConstants.K5DbGroup sortMethod = K5SrvConstants.K5DbGroup.SortDefault)
+    {
+      CheckIfDisposed();
+
+      List<DbGroup> groupList = new List<DbGroup>();
+
+      if (_projectHandle == 0)
+        return groupList;
+
+      uint nbGroup = DbSrv.GetNbGroup(_clientHandle, _projectHandle);
+      if (nbGroup == 0)
+        return groupList;
+
+      //create group array
+      uint[] arrGroup = new uint[nbGroup];
+      DbSrv.GetSortedGroups(_clientHandle, _projectHandle, arrGroup, (uint)sortMethod);
+
+      for (uint uGroup = 0; uGroup < nbGroup; uGroup++)
+      {
+        DbGroup group = new DbGroup();
+        groupList.Add(group);
+        GetGroupDesc(arrGroup[uGroup], ref group);
+      }
+
+      return groupList;
+    }
+
+    /// <summary>
+    ///   Get description of the specified group
+    /// </summary>
+    /// <returns> Bool, true if description found</returns>
+    /// <param name="groupHandle">The group handle.</param>
+    /// <param name="group">The group (object DbGroup).</param>
+    public bool GetGroupDesc(uint groupHandle, ref DbGroup group)
+    {
+      CheckIfDisposed();
+
+      group.Id = groupHandle;
+
+      IntPtr ptrName = DbSrv.GetGroupDesc(_clientHandle, _projectHandle, groupHandle, ref group.GroupStyle,
+        ref group.IoType, ref group.Slot, ref group.SubSlot, ref group.Var);
+      group.Name = Marshal.PtrToStringAnsi(ptrName);
+
+      return group.Name != null;
+    }
+
+    /// <summary>
+    ///   Returns the group id
+    /// </summary>
+    /// <param name="group">Name of the group.</param>
+    public uint FindGroup(string group)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindGroup(_clientHandle, _projectHandle, group);
+    }
+
+    /// <summary>
+    ///   Locks the group
+    /// </summary>
+    public bool LockGroup(uint groupHandle, bool groupLock, bool withVar = false)
+    {
+      CheckIfDisposed();
+
+      bool bSet;
+
+      if (groupLock)
+      {
+        if (withVar)
+          bSet = DbSrv.LockGroupEx(_clientHandle, _projectHandle, groupHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+        else
+          bSet = DbSrv.LockGroup(_clientHandle, _projectHandle, groupHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+      }
+      else
+      {
+        if (withVar)
+          bSet = DbSrv.UnlockGroupEx(_clientHandle, _projectHandle, groupHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+        else
+          bSet = DbSrv.UnlockGroup(_clientHandle, _projectHandle, groupHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+      }
+
+      return bSet;
+    }
+
+    /// <summary>
+    ///   Gets the related group id from a program or type
+    /// </summary>
+    /// <param name="id">Id of the program or type.</param>
+    public uint GetRelatedGroupId(uint id) // program or type
+    {
+      CheckIfDisposed();
+
+      uint group = 0;
+
+      switch (GetKindOfObject(id))
+      {
+        case K5SrvConstants.K5DbObj.Program:
+          DbProgram prog = new DbProgram();
+          if (GetProgramDesc(id, ref prog))
+            group = FindGroup(prog.Name);
+          break;
+
+        case K5SrvConstants.K5DbObj.Group:
+          group = id;
+          break;
+
+        case K5SrvConstants.K5DbObj.Type:
+          DbType type = new DbType();
+          if (GetTypeDesc(id, ref type))
+            group = FindGroup(type.Name);
+          break;
+      }
+
+      return group;
+    }
+
+    /// <summary>
+    ///   Gets the owner of a group
+    /// </summary>
+    /// <param name="groupHandle">Handle of the group.</param>
+    public string GetGroupOwner(uint groupHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetGroupOwner(_clientHandle, _projectHandle, groupHandle);
+    }
+
+    /// <summary>
+    ///   Get the var list in group from database
+    /// </summary>
+    /// <returns> List which contains the found variables.</returns>
+    /// <param name="groupHandle">The group where variables are declared.</param>
+    /// <param name="sortMethod">The sorting method to retrieve variables.</param>
+    public List<DbVar> GetVars(uint groupHandle, K5SrvConstants.K5DbVar sortMethod = K5SrvConstants.K5DbVar.SortByName)
+    {
+      CheckIfDisposed();
+
+      List<DbVar> variableList = new List<DbVar>();
+
+      if (_projectHandle == 0)
+        return variableList;
+
+      uint nbVar = DbSrv.GetNbVar(_clientHandle, _projectHandle, groupHandle);
+      if (nbVar == 0)
+        return variableList;
+
+      //create group array
+      uint[] arrVar = new uint[nbVar];
+      DbSrv.GetSortedVars(_clientHandle, _projectHandle, groupHandle, (uint)sortMethod, arrVar);
+
+      for (uint uVar = 0; uVar < nbVar; uVar++)
+      {
+        DbVar var = new DbVar();
+        variableList.Add(var);
+        GetVarDesc(arrVar[uVar], ref var);
+      }
+
+      return variableList;
+    }
+
+    /// <summary>
+    ///   Get description of the specified variable
+    /// </summary>
+    /// <returns> Bool, true if description found.</returns>
+    /// <param name="variableHandle">The variable handle.</param>
+    /// <param name="var">The variable (object DbVar).</param>
+    public bool GetVarDesc(uint variableHandle, ref DbVar var)
+    {
+      CheckIfDisposed();
+
+      var.Id = variableHandle;
+
+      uint groupHandle = GetVarGroup(variableHandle);
+      IntPtr ptrName = DbSrv.GetVarDesc(_clientHandle, _projectHandle, groupHandle, variableHandle, ref var.Type, ref var.Dim,
+        ref var.StringLength, ref var.Flags);
+      var.Name = Marshal.PtrToStringAnsi(ptrName);
+
+      uint dwValid = 0;
+      var.InitialValue = GetVarInitValue(groupHandle, variableHandle, ref dwValid);
+
+      return var.Name != null;
+    }
+
+    /// <summary>
+    ///   Gets the group of a variable
+    /// </summary>
+    /// <param name="variableHandle">Handle of the variable.</param>
+    public uint GetVarGroup(uint variableHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetVarGroup(_clientHandle, _projectHandle, variableHandle);
+    }
+
+    /// <summary>
+    ///   Searches a variable in a group and returns variable id
+    /// </summary>
+    /// <param name="groupHandle">Handle of the group.</param>
+    /// <param name="varName">Variable name.</param>
+    public uint FindVarInGroup(uint groupHandle, string varName)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindVarInGroup(_clientHandle, _projectHandle, groupHandle, varName);
+    }
+
+    /// <summary>
+    ///   Searches variable in project
+    /// </summary>
+    /// <param name="name"Variable name.</param>
+    public uint FindVarAnywhere(string name, uint localGroupHandle = 0, bool findExact = false)
+    {
+      CheckIfDisposed();
+
+      uint flags = 0;
+
+      if (findExact)
+        flags = (uint)K5SrvConstants.K5DbVar.FindExact;
+      return DbSrv.FindVar(_clientHandle, _projectHandle, name, 0xFFFFFFFF, localGroupHandle, flags);
+    }
+
+    /// <summary>
+    ///   Creates variable
+    /// </summary>
+    /// <param name="groupHandle">Handle of group where variable is created.</param>
+    /// <param name="typeHandle">Handle of the variable type.</param>
+    /// <param name="dimension">Dimension.</param>
+    /// <param name="stringLength">Max string length.</param>
+    /// <param name="flags">Flags.</param>
+    /// <param name="varName">Handle of the variable type.</param>
+    public uint CreateVar(uint groupHandle, uint typeHandle, uint dimension, uint stringLength, uint flags,
+      string varName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CreateVar(_clientHandle, _projectHandle, groupHandle, 0xFFFFFFFF, typeHandle, dimension, stringLength, flags,
+        varName);
+    }
+
+    /// <summary>
+    ///   Deltes the variable
+    /// </summary>
+    /// <param name="groupHandle">Handle of the group.</param>
+    /// <param name="typeHandle">Handle of the variable.</param>
+    public bool DeleteVar(uint groupHandle, uint variableHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.DeleteVar(_clientHandle, _projectHandle, groupHandle, variableHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Renames a variable
+    /// </summary>
+    /// <param name="groupHandle">Handle of group.</param>
+    /// <param name="variableHandle">Handle of the variable.</param>
+    /// <param name="newName">New name of the variable.</param>
+    public bool RenameVar(uint groupHandle, uint variableHandle, string newName)
+    {
+      CheckIfDisposed();
+      return DbSrv.RenameVar(_clientHandle, _projectHandle, groupHandle, variableHandle, newName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Checks if variables can be renamed
+    /// </summary>
+    /// <param name="groupHandle">Handle of group.</param>
+    /// <param name="variableHandle">Handle of the variable.</param>
+    /// <param name="newName">New name of the variable.</param>
+    public bool CanRenameVar(uint groupHandle, uint variableHandle, string newName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CanRenameVar(_clientHandle, _projectHandle, groupHandle, variableHandle, newName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public string GetVarPrevName(uint variableHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetVarPrevName(_clientHandle, _projectHandle, variableHandle);
+    }
+
+    public bool SetVarDesc(uint groupHandle, uint variableHandle, uint typeHandle, uint dimension, uint stringLength,
+      uint flags)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetVarDesc(_clientHandle, _projectHandle, groupHandle, variableHandle, typeHandle, dimension, stringLength, flags) ==
+             (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool CanSetVarDesc(uint groupHandle, uint variableHandle, uint typeHandle, uint dimension, uint stringLength,
+      uint flags)
+    {
+      CheckIfDisposed();
+      return DbSrv.CanSetVarDesc(_clientHandle, _projectHandle, groupHandle, variableHandle, typeHandle, dimension, stringLength, flags) ==
+             (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool SetVarInitValue(uint groupHandle, uint variableHandle, string value)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetVarInitValue(_clientHandle, _projectHandle, groupHandle, variableHandle, value) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool CheckVarInitValue(uint groupHandle, uint variableHandle, string value)
+    {
+      CheckIfDisposed();
+      return DbSrv.CheckVarInitValue(_clientHandle, _projectHandle, groupHandle, variableHandle, value) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public string GetVarInitValue(uint groupHandle, uint variableHandle, ref uint valid)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetVarInitValue(_clientHandle, _projectHandle, groupHandle, variableHandle, ref valid);
+    }
+
+    public bool LockVar(uint groupHandle, uint variableHandle, bool lockVariable)
+    {
+      CheckIfDisposed();
+
+      if (lockVariable)
+      {
+        return DbSrv.LockVar(_clientHandle, _projectHandle, groupHandle, variableHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+      }
+      
+      return DbSrv.UnlockVar(_clientHandle, _projectHandle, groupHandle, variableHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Returns owner of the variable
+    /// </summary>
+    /// <param name="variableHandle">Handle of the variable.</param>
+    public string GetVarOwner(uint variableHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetVarOwner(_clientHandle, _projectHandle, variableHandle);
+    }
+
+    public uint FindVar(string symbol, uint startPosHandle, uint localGroupHandle, uint flags)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindVar(_clientHandle, _projectHandle, symbol, startPosHandle, localGroupHandle, flags);
+    }
+
+    public uint FindProgramVar(uint programHandle, string varName, ref uint groupHandle, ref uint local)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindProgramVar(_clientHandle, _projectHandle, programHandle, varName, ref groupHandle, ref local);
+    }
+
+    public uint GetVarDimensions(uint groupHandle, uint variableHandle, uint bufferSize, uint[] arrFims)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetVarDimensions(_clientHandle, _projectHandle, groupHandle, variableHandle, bufferSize, arrFims);
+    }
+
+    public bool SetVarDimensions(uint groupHandle, uint variableHandle, uint bufferSize, uint[] arrFims)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetVarDimensions(_clientHandle, _projectHandle, groupHandle, variableHandle, bufferSize, arrFims) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public string SelectVar(string text, ref SelectedVariable selectedVariable, ref uint variableHandle)
+    {
+      CheckIfDisposed();
+
+      string symbolNameNew = null;
+
+      if (DbSrv.SelectVar(_clientHandle, _projectHandle, text, ref selectedVariable, ref variableHandle))
+      {
+        //when user click ok, the database can return the selected variable
+        IntPtr ptr = DbSrv.GetSerBuffer(_clientHandle);
+        symbolNameNew = Marshal.PtrToStringAnsi(ptr);
+        DbSrv.ReleaseSerBuffer(_clientHandle);
+      }
+
+      return symbolNameNew;
+    }
+
+    public string SerializeVar(uint variableHandle)
+    {
+      CheckIfDisposed();
+
+      DbSrv.ReleaseSerBuffer(_clientHandle);
+
+      DbSrv.SerializeVar(_clientHandle, _projectHandle, GetVarGroup(variableHandle), variableHandle);
+      IntPtr ptrSer = DbSrv.GetSerBuffer(_clientHandle);
+      string serial = Marshal.PtrToStringAnsi(ptrSer);
+
+      DbSrv.ReleaseSerBuffer(_clientHandle);
+
+      return serial;
+    }
+
+    public uint PasteSerializedVar(uint groupHandle, string serial)
+    {
+      CheckIfDisposed();
+
+      DbSrv.SetSerBuffer(_clientHandle, serial);
+      uint hVar = DbSrv.PasteSerializedVar(_clientHandle, _projectHandle, groupHandle, 0xFFFFFFFF);
+      DbSrv.ReleaseSerBuffer(_clientHandle);
+
+      return hVar;
+    }
+
+    /// <summary>
+    ///   Get the properties of a database object
+    /// </summary>
+    /// <returns> List which contains the found properties.</returns>
+    /// <param name="objectHandle">The object Id.</param>
+    public List<DbProp> GetProperties(uint objectHandle)
+    {
+      CheckIfDisposed();
+
+      List<DbProp> propertyList = new List<DbProp>();
+
+      if (_projectHandle == 0)
+        return propertyList;
+
+      uint nbProp = DbSrv.GetNbProp(_clientHandle, _projectHandle, objectHandle);
+      if (nbProp == 0)
+        return propertyList;
+
+      //create prop array
+      uint[] arrProp = new uint[nbProp];
+      DbSrv.GetProps(_clientHandle, _projectHandle, objectHandle, arrProp);
+
+      for (uint uProp = 0; uProp < nbProp; uProp++)
+      {
+        DbProp prop = new DbProp();
+        propertyList.Add(prop);
+
+        prop.Id = arrProp[uProp];
+        prop.Value = GetProperty(objectHandle, (K5SrvConstants.K5DbProperty)prop.Id);
+      }
+
+      return propertyList;
+    }
+
+    /// <summary>
+    ///   Sets a property of an object
+    /// </summary>
+    /// <param name="objectHandle">Handle of the object.</param>
+    /// <param name="propertyHandle">Handle of the property.</param>
+    /// <param name="value">New value of the object.</param>
+    public bool SetProperty(uint objectHandle, K5SrvConstants.K5DbProperty propertyHandle, string value)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetProperty(_clientHandle, _projectHandle, objectHandle, (uint)propertyHandle, value) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Returns the value of a property
+    /// </summary>
+    /// <param name="objectHandle">Handle of the object.</param>
+    /// <param name="propertyHandle">Handle of the property.</param>
+    public string GetProperty(uint objectHandle, K5SrvConstants.K5DbProperty propertyHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.GetProperty(_clientHandle, _projectHandle, objectHandle, propertyHandle);
+    }
+
+    /// <summary>
+    ///   Removes all properties
+    /// </summary>
+    /// <param name="objectHandle">Handle of the object.</param>
+    public bool RemoveProperties(uint objectHandle)
+    {
+      CheckIfDisposed();
+      return DbSrv.RemoveProperties(_clientHandle, _projectHandle, objectHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Returns comment of an object
+    /// </summary>
+    /// <param name="objectHandle">Handle of the object.</param>
+    /// <param name="commentType">Type of comment.</param>
+    public string GetComment(uint objectHandle, uint commentType)
+    {
+      CheckIfDisposed();
+
+      string comment = string.Empty;
+
+      uint nbComm = DbSrv.GetCommentLength(_clientHandle, _projectHandle, objectHandle, commentType);
+      if (nbComm > 0)
+      {
+        StringBuilder szBuffer = new StringBuilder((int)nbComm + 1);
+        DbSrv.GetComment(_clientHandle, _projectHandle, objectHandle, commentType, szBuffer, nbComm + 1);
+        comment = szBuffer.ToString();
+      }
+
+      return comment;
+    }
+
+    /// <summary>
+    ///   Sets the comment of an object
+    /// </summary>
+    /// <param name="objectHandle">Handle of the object.</param>
+    /// <param name="commentType">Type of the comment.</param>
+    /// <param name="value">Comment.</param>
+    public bool SetComment(uint objectHandle, uint commentType, string value)
+    {
+      CheckIfDisposed();
+      return DbSrv.SetComment(_clientHandle, _projectHandle, objectHandle, commentType, value) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+
+    public string SerUserGroups()
+    {
+      CheckIfDisposed();
+
+      DbSrv.SerUserGroups(_clientHandle, _projectHandle);
+      IntPtr ptr = DbSrv.GetSerBuffer(_clientHandle);
+      string sUserGroups = Marshal.PtrToStringAnsi(ptr);
+      DbSrv.ReleaseSerBuffer(_clientHandle);
+
+      return sUserGroups;
+    }
+
+    public string GetGlobalFilePath(string suffix)
+    {
+      CheckIfDisposed();
+
+      StringBuilder str = new StringBuilder(260);
+      DbSrv.GetGlobalFilePath(_clientHandle, _projectHandle, suffix, str);
+      string path = str.ToString();
+
+      return path;
+    }
+
+    public string GetEqvPath(bool common, uint programHandle)
+    {
+      CheckIfDisposed();
+
+      StringBuilder str = new StringBuilder(260);
+      if (common)
+        DbSrv.GetEqvPath(_clientHandle, _projectHandle, 1, programHandle, str);
+      else
+        DbSrv.GetEqvPath(_clientHandle, _projectHandle, 0, programHandle, str);
+      string sPath = str.ToString();
+
+      return sPath;
+    }
+
+    public bool PutHotSettings(bool enabled, uint dwStamp, string settings)
+    {
+      CheckIfDisposed();
+
+      uint dwEnabled = 0;
+      if (enabled)
+        dwEnabled = 1;
+      return DbSrv.PutHotSettings(_clientHandle, _projectHandle, dwEnabled, dwStamp, settings) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public string GetHotSettings(out bool enabled, out uint stamp)
+    {
+      CheckIfDisposed();
+
+      string sProp = GetProperty(_projectHandle, K5SrvConstants.K5DbProperty.EnableHot);
+
+      enabled = (sProp != null);
+
+      string sStamp = GetProperty(_projectHandle, K5SrvConstants.K5DbProperty.LastChange);
+      if (sStamp != null)
+        stamp = uint.Parse(sStamp);
+      else
+        stamp = 0;
+
+      string settings = GetProperty(_projectHandle, K5SrvConstants.K5DbProperty.TargetSizing);
+
+      return settings;
+    }
+
+    /// <summary>
+    ///   Retruns if hot is enabled in the project
+    /// </summary>
+    public bool IsHotEnabled()
+    {
+      CheckIfDisposed();
+      return DbSrv.IsHotEnabled(_clientHandle, _projectHandle) != 0;
+    }
+
+    /// <summary>
+    ///   Sets buffer size of HOT
+    /// </summary>
+    /// <param name="settings"Buffer size.</param>
+    public void SetHotSizing(string settings)
+    {
+      CheckIfDisposed();
+      DbSrv.SetHotSizing(_clientHandle, _projectHandle, settings);
+    }
+
+    /// <summary>
+    ///   Toggles the hot setting
+    /// </summary>
+    /// <param name="enable">State of the hot setting.</param>
+    public void SetHot(bool enable)
+    {
+      CheckIfDisposed();
+
+      if (enable)
+        DbSrv.EnableHot(_clientHandle, _projectHandle);
+      else
+        DbSrv.DisableHot(_clientHandle, _projectHandle);
+    }
+
+    public bool CleanHotTracks()
+    {
+      CheckIfDisposed();
+      return DbSrv.CleanHotTracks(_clientHandle, _projectHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Enumerate child sub items of a complex item
+    /// </summary>
+    /// <returns> list of sub items, separated by \t eg for an array: tab -> tab[% u] min = 0 max=9 str -> item1\titem2</returns>
+    /// <param name="parentProgramHandle">Handle of parent program or NULL.</param>
+    /// <param name="text">Input text = expression.</param>
+    /// <param name="minIndex">Start index for enumeration (if % in result).</param>
+    /// <param name="maxIndex">Stop index for enumeration (if % in result).</param>
+    /// <param name="variableHandle">Handle of leave item.</param>
+    public string GetExpSubItems(uint parentProgramHandle, string text, ref uint minIndex, ref uint maxIndex,
+      ref uint variableHandle)
+    {
+      CheckIfDisposed();
+      DbSrv.GetExpSubItems(_clientHandle, _projectHandle, parentProgramHandle, text, ref minIndex, ref maxIndex, ref variableHandle);
+
+      IntPtr ptr = DbSrv.GetSerBuffer(_clientHandle);
+      string str = Marshal.PtrToStringAnsi(ptr);
+      DbSrv.ReleaseSerBuffer(_clientHandle);
+
+      return str;
+    }
+
+    /// <summary>
+    ///    Get the file list in database
+    /// </summary>
+    /// <returns> List which contains the found files</returns>
+    /// <param name="suffixes">NULL or list of suffixes separated by '|' - ex: ".rcp|.spy".</param>
+    public List<DbFile> GetFiles(string suffixes)
+    {
+      CheckIfDisposed();
+
+      List<DbFile> fileList = new List<DbFile>();
+
+      if (_projectHandle == 0)
+        return fileList;
+
+      uint nbFile = DbSrv.GetNbFile(_clientHandle, _projectHandle, suffixes);
+
+      if (nbFile == 0)
+        return fileList;
+
+      uint[] arrFile = new uint[nbFile];
+      DbSrv.GetFiles(_clientHandle, _projectHandle, suffixes, arrFile);
+
+      for (uint uFile = 0; uFile < nbFile; uFile++)
+      {
+        DbFile file = new DbFile();
+        fileList.Add(file);
+        GetFileDesc(arrFile[uFile], ref file);
+      }
+
+      return fileList;
+    }
+
+    /// <summary>
+    ///    Get description of the specified file
+    /// </summary>
+    /// <returns> List which contains the found files</returns>
+    /// <param name="fileHandle">The file handle.</param>
+    /// <param name="file">The file (object DbFile).</param>
+    public bool GetFileDesc(uint fileHandle, ref DbFile file)
+    {
+      CheckIfDisposed();
+
+      file.Id = fileHandle;
+
+      IntPtr ptr = DbSrv.GetFileDesc(_clientHandle, _projectHandle, fileHandle);
+      file.Value = Marshal.PtrToStringAnsi(ptr);
+
+      return file.Value != null;
+    }
+
+    /// <summary>
+    ///   Searches file
+    /// </summary>
+    /// <param name="name">Name of the file.</param>
+    public uint FindFile(string name)
+    {
+      CheckIfDisposed();
+      return DbSrv.FindFile(_clientHandle, _projectHandle, name);
+    }
+
+    /// <summary>
+    ///   Checks if file can be created
+    /// </summary>
+    /// <param name="name">Name of the file.</param>
+    public bool CanCreateFile(string name)
+    {
+      CheckIfDisposed();
+      return DbSrv.CanCreateFile(_clientHandle, _projectHandle, name) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Creates file
+    /// </summary>
+    /// <param name="name">Name of the file.</param>
+    public uint CreateFile(string name)
+    {
+      CheckIfDisposed();
+      return DbSrv.CreateFile(_clientHandle, _projectHandle, name);
+    }
+
+    /// <summary>
+    ///   Renames file
+    /// </summary>
+    /// <param name="name">Name of the file.</param>
+    /// <param name="newName">New name of the file.</param>
+    public bool RenameFile(uint handleFile, string newName)
+    {
+      CheckIfDisposed();
+      return DbSrv.RenameFile(_clientHandle, _projectHandle, handleFile, newName) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Deletes files
+    /// </summary>
+    /// <param name="handleFile">Handle of the file.</param>
+    public bool DeleteFile(uint handleFile)
+    {
+      CheckIfDisposed();
+      return DbSrv.DeleteFile(_clientHandle, _projectHandle, handleFile) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Locks the file
+    /// </summary>
+    /// <param name="handleFile">Handle of the file.</param>
+    /// <param name="fileLock">Lock state of file.</param>
+    public bool LockFile(uint handleFile, bool fileLock)
+    {
+      CheckIfDisposed();
+
+      if (fileLock)
+        return DbSrv.LockFile(_clientHandle, _projectHandle, handleFile) == (uint)K5SrvConstants.K5DbErr.Ok;
+      else
+        return DbSrv.UnlockFile(_clientHandle, _projectHandle, handleFile) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Saves changes of files
+    /// </summary>
+    /// <param name="handleFile">Handle of the file.</param>
+    public bool SaveFileChanges(uint handleFile)
+    {
+      CheckIfDisposed();
+      return DbSrv.SaveFileChanges(_clientHandle, _projectHandle, handleFile) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    public bool LookForNewFiles()
+    {
+      CheckIfDisposed();
+      return DbSrv.LookForNewFiles(_clientHandle, _projectHandle) == (uint)K5SrvConstants.K5DbErr.Ok;
+    }
+
+    /// <summary>
+    ///   Copies a file
+    /// </summary>
+    /// <param name="fileHandle">Handle of the file.</param>
+    /// <param name="destinationName">New location.</param>
+    public uint CopyFile(uint fileHandle, string destinationName)
+    {
+      CheckIfDisposed();
+      return DbSrv.CopyFile(_clientHandle, _projectHandle, fileHandle, destinationName);
+    }
+
+    /// <summary>
+    ///   Closes the database connection
+    /// </summary>
+    public void Dispose()
+    {
+      if (isDisposed)
+        return;
+
+      Close();
+
+      isDisposed = true;
+    }
+
+    /// <summary>
+    ///   Checks if conection to database was closed
+    /// </summary>
+    public void CheckIfDisposed()
+    {
+      if(isDisposed)
+        throw new ObjectDisposedException("K5Srv", "The instance was already disposed");
+    }
+  }
+}

--- a/zenonApi.Logic.Integration/K5Srv/SelectedVariable.cs
+++ b/zenonApi.Logic.Integration/K5Srv/SelectedVariable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace zenonApi.Zenon.K5Srv
+{
+  [StructLayout(LayoutKind.Sequential)]
+  public struct SelectedVariable
+  {
+    public uint parentGroup;
+    public uint prefType;
+    public IntPtr handleWindowParent;
+    public K5Point pointerPos;
+    public uint dwOptions;
+  }
+
+  //structures for K5DB_SelectVar
+  [StructLayout(LayoutKind.Sequential)]
+  public struct K5Point
+  {
+    public int x;
+    public int y;
+  }
+}

--- a/zenonApi.Logic.Integration/LazyLogicProject.cs
+++ b/zenonApi.Logic.Integration/LazyLogicProject.cs
@@ -4,7 +4,6 @@ using System.Xml.Linq;
 using zenonApi.Logic.Ini;
 using zenonApi.Zenon.Helper;
 using zenonApi.Zenon.K5Prp;
-using zenonApi.Zenon.StratonUtilities;
 
 // ReSharper disable once CheckNamespace : Intended, to fit into the object hierarchy of the logic API.
 namespace zenonApi.Logic

--- a/zenonApi.Logic.Integration/Zenon.cs
+++ b/zenonApi.Logic.Integration/Zenon.cs
@@ -186,6 +186,8 @@ namespace zenonApi.Zenon
             newStratonNgDriverId);
         }
 
+        // Due to a change in zenon Logic 10, the compiler settings and further other options need to be set explicitly.
+        k5ToolSet.TryApplySettings(logicProject);
         k5ToolSet.ImportZenonLogicProject(logicProject);
       }
 

--- a/zenonApi.Logic.Integration/ZenonCom.cs
+++ b/zenonApi.Logic.Integration/ZenonCom.cs
@@ -76,7 +76,11 @@ namespace zenonApi.Zenon
     /// </summary>
     /// <param name="zenonLogicProjectName">The name of the zenon Logic project.</param>
     /// <param name="reloadZenonProject">Specifies if the current zenon project shall be reloaded after the import.</param>
-    public void ImportLogicProjectIntoZenonByName(string zenonLogicProjectName, bool reloadZenonProject = true)
+    /// <param name="options">Specifies options on how to import the projects into zenon.</param>
+    public void ImportLogicProjectIntoZenonByName(
+      string zenonLogicProjectName,
+      bool reloadZenonProject = true,
+      ImportOptions options = ImportOptions.Default)
     {
       if (string.IsNullOrWhiteSpace(zenonLogicProjectName))
       {
@@ -95,22 +99,23 @@ namespace zenonApi.Zenon
           string.Format(Strings.LogicProjectWithSpecifiedProjectNameNotFound, zenonLogicProjectName));
       }
 
-      ImportLogicProjectsIntoZenon(logicProjectsWithSearchedNames, reloadZenonProject);
+      ImportLogicProjectsIntoZenon(logicProjectsWithSearchedNames, reloadZenonProject, options);
     }
 
     /// <summary>
-    /// Imports all zenon Logic projects which are stored in <see cref="LogicProjects"/> into zenon
+    /// Imports all zenon Logic projects which are stored in <see cref="LogicProjects"/> into zenon.
     /// </summary>
-    public void ImportLogicProjectsIntoZenon(bool reloadZenonProject = true)
+    /// <param name="reloadZenonProject">Specifies if the current zenon project shall be reloaded after the import.</param>
+    /// <param name="options">Specifies options on how to import the project into zenon.</param>
+    public void ImportLogicProjectsIntoZenon(bool reloadZenonProject = true, ImportOptions options = ImportOptions.Default)
     {
-      ImportLogicProjectsIntoZenon(LogicProjects, reloadZenonProject);
+      ImportLogicProjectsIntoZenon(LogicProjects, reloadZenonProject, options);
     }
 
     /// <summary>
     /// Returns zenon Logic project reference for the stated project name.
     /// </summary>
-    /// <param name="zenonLogicProjectName"></param>
-    /// <returns></returns>
+    /// <param name="zenonLogicProjectName">The zenon Logic project to load.</param>
     public LogicProject GetLogicProjectByName(string zenonLogicProjectName)
     {
       if (string.IsNullOrEmpty(zenonLogicProjectName))
@@ -158,9 +163,15 @@ namespace zenonApi.Zenon
     /// Imports the stated zenon Logic projects into zenon Logic.
     /// As an import requires an existing project it tries to create a default project first.
     /// </summary>
-    /// <param name="zenonLogicProjectsToImport"></param>
-    private void ImportLogicProjectsIntoZenon(IEnumerable<LogicProject> zenonLogicProjectsToImport, bool reloadZenonProject = true)
+    /// <param name="zenonLogicProjectsToImport">The zenon Logic projects to import.</param>
+    /// <param name="reloadZenonProject">Specifies if the current zenon project shall be reloaded after the import.</param>
+    /// <param name="options">Specifies options on how to import the <paramref name="zenonLogicProjectsToImport"/> into zenon.</param>
+    private void ImportLogicProjectsIntoZenon(
+      IEnumerable<LogicProject> zenonLogicProjectsToImport, 
+      bool reloadZenonProject,
+      ImportOptions options)
     {
+      EnsureSupportedVersion(options);
       foreach (LogicProject logicProject in zenonLogicProjectsToImport)
       {
         if (!logicProject.Path.Contains(this.ZenonProjectGuid))
@@ -195,7 +206,7 @@ namespace zenonApi.Zenon
 
         // Due to a change in zenon Logic 10, the compiler settings and further other options need to be set explicitly.
         k5ToolSet.TryApplySettings(logicProject);
-        k5ToolSet.ImportZenonLogicProject(logicProject);
+        k5ToolSet.ImportZenonLogicProject(logicProject, options);
       }
 
       if (reloadZenonProject)
@@ -205,6 +216,25 @@ namespace zenonApi.Zenon
         workspace.UnloadProject2(ZenonProjectGuid, true);
         workspace.LoadProject(ZenonProjectGuid);
       }
+    }
+
+    private void EnsureSupportedVersion(ImportOptions options)
+    {
+      if (options == ImportOptions.Default)
+      {
+        return;
+      }
+
+      var version = ZenonProject.Parent.Parent.VersionNumber;
+      if (version >= 10000)
+      {
+        return;
+      }
+
+      throw new ArgumentException(
+        $"The given import option requires zenon in version 10 or higher. "
+        + $"Use {nameof(ImportOptions)}.{nameof(ImportOptions.Default)} instead for lower versions.",
+        nameof(options));
     }
 
     /// <summary>

--- a/zenonApi.Logic.Integration/ZenonCom.cs
+++ b/zenonApi.Logic.Integration/ZenonCom.cs
@@ -193,6 +193,8 @@ namespace zenonApi.Zenon
           );
         }
 
+        // Due to a change in zenon Logic 10, the compiler settings and further other options need to be set explicitly.
+        k5ToolSet.TryApplySettings(logicProject);
         k5ToolSet.ImportZenonLogicProject(logicProject);
       }
 

--- a/zenonApi.Logic.Integration/ZenonCom.cs
+++ b/zenonApi.Logic.Integration/ZenonCom.cs
@@ -205,7 +205,7 @@ namespace zenonApi.Zenon
         }
 
         // Due to a change in zenon Logic 10, the compiler settings and further other options need to be set explicitly.
-        k5ToolSet.TryApplySettings(logicProject);
+        k5ToolSet.TryApplySettings(logicProject, options);
         k5ToolSet.ImportZenonLogicProject(logicProject, options);
       }
 

--- a/zenonApi.Logic.Integration/zenonApi.Zenon.csproj
+++ b/zenonApi.Logic.Integration/zenonApi.Zenon.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helper\TemporaryFileCreator.cs" />
+    <Compile Include="ImportOptions.cs" />
     <Compile Include="LazyLogicProject.cs" />
     <Compile Include="StratonUtilities\StratonFolderPath.cs" />
     <Compile Include="K5Prp\K5ToolSet.cs" />

--- a/zenonApi.Logic.Integration/zenonApi.Zenon.csproj
+++ b/zenonApi.Logic.Integration/zenonApi.Zenon.csproj
@@ -78,6 +78,16 @@
   <ItemGroup>
     <Compile Include="Helper\TemporaryFileCreator.cs" />
     <Compile Include="ImportOptions.cs" />
+    <Compile Include="K5Srv\DbFile.cs" />
+    <Compile Include="K5Srv\DbGroup.cs" />
+    <Compile Include="K5Srv\DbProp.cs" />
+    <Compile Include="K5Srv\DbSrv.cs" />
+    <Compile Include="K5Srv\DbProgram.cs" />
+    <Compile Include="K5Srv\DbType.cs" />
+    <Compile Include="K5Srv\DbVar.cs" />
+    <Compile Include="K5Srv\K5SrvConstants.cs" />
+    <Compile Include="K5Srv\K5SrvWrapper.cs" />
+    <Compile Include="K5Srv\SelectedVariable.cs" />
     <Compile Include="LazyLogicProject.cs" />
     <Compile Include="StratonUtilities\StratonFolderPath.cs" />
     <Compile Include="K5Prp\K5ToolSet.cs" />
@@ -120,6 +130,7 @@
   <ItemGroup>
     <None Include="zenonApi.Zenon.nuspec" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <ScadaBuildTarget>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\COPA-DATA\DataDir@ProgramDir32_Common)\AddInFramework\AddInFramework.Build.Common.targets</ScadaBuildTarget>

--- a/zenonApi.Logic/LogicDataTypeKind.cs
+++ b/zenonApi.Logic/LogicDataTypeKind.cs
@@ -36,6 +36,16 @@ namespace zenonApi.Logic
     /// data structure.
     /// </summary>
     [zenonSerializableEnum("STRUCT")]
-    DataStructure
+    DataStructure,
+    /// <summary>
+    /// Indicates that a used data type is a bitfield.
+    /// </summary>
+    [zenonSerializableEnum("BITFIELD")]
+    BitField,
+    /// <summary>
+    /// Indicates that a used data type is an enumeration.
+    /// </summary>
+    [zenonSerializableEnum("ENUM")]
+    Enumeration
   }
 }


### PR DESCRIPTION
CD-FR changed how K5B.exe XMLMERGE is working: Compiler settings are gone in zenon 10 when this API is used. Now we have to explicitly set the compiler settings via K5PRP.
Problem occurred in two of our bigger client projects.
Also a value in an enum was missing (BITFIELD), which caused a problem in one client project